### PR TITLE
config refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ class OtherModel < ActiveRecord::Base
   include AttrJson::Record
 
   # as a default for the model
-  self.default_json_container_attribute = :some_other_column_name
+  attr_json_config(default_container_attribute: :some_other_column_name)
 
   # now this is going to serialize to column 'some_other_column_name'
   attr_json :my_int, :integer

--- a/lib/attr_json.rb
+++ b/lib/attr_json.rb
@@ -3,6 +3,7 @@ require "attr_json/version"
 require "active_record"
 require "active_record/connection_adapters/postgresql_adapter"
 
+require 'attr_json/config'
 require 'attr_json/record'
 require 'attr_json/model'
 require 'attr_json/nested_attributes'

--- a/lib/attr_json/config.rb
+++ b/lib/attr_json/config.rb
@@ -1,0 +1,45 @@
+module AttrJson
+  # Intentionally non-mutable, to avoid problems with subclass inheritance
+  # and rails class_attribute. Instead, you set to new Config object
+  # changed with {#merge}.
+  class Config
+    RECORD_ALLOWED_KEYS = %i{default_container_attribute}
+    MODEL_ALLOWED_KEYS = %i{unknown_key}
+    DEFAULTS = {
+      default_container_attribute: "json_attributes",
+      unknown_key: :raise
+    }
+
+    (MODEL_ALLOWED_KEYS + RECORD_ALLOWED_KEYS).each do |key|
+      define_method(key) do
+        attributes[key]
+      end
+    end
+
+    attr_reader :mode
+
+    def initialize(options = {})
+      @mode = options.delete(:mode)
+      unless mode == :record || mode == :model
+        raise ArgumentError, "required :mode argument must be :record or :model"
+      end
+      valid_keys = mode == :record ? RECORD_ALLOWED_KEYS : MODEL_ALLOWED_KEYS
+      options.assert_valid_keys(valid_keys)
+
+      options.reverse_merge!(DEFAULTS.slice(*valid_keys))
+
+      @attributes = options
+    end
+
+    # Returns a new Config object, with changes merged in.
+    def merge(changes = {})
+      self.class.new(attributes.merge(changes).merge(mode: mode))
+    end
+
+    protected
+
+    def attributes
+      @attributes
+    end
+  end
+end

--- a/lib/attr_json/model.rb
+++ b/lib/attr_json/model.rb
@@ -51,12 +51,25 @@ module AttrJson
 
     class_methods do
       def attr_json_config(new_values = {})
-        @attr_json_config ||= Config.new(mode: :model)
         if new_values.present?
-          @attr_json_config = @attr_json_config.merge(new_values)
+          # get one without new values, then merge new values into it, and
+          # set it locally for this class.
+          @attr_json_config = attr_json_config.merge(new_values)
+        else
+          if instance_variable_defined?("@attr_json_config")
+            # we have a custom one for this class, return it.
+            @attr_json_config
+          elsif superclass.respond_to?(:attr_json_config)
+            # return superclass without setting it locally, so changes in superclass
+            # will continue effecting us.
+            superclass.attr_json_config
+          else
+            # no superclass, no nothing, set it to blank one.
+            @attr_json_config = Config.new(mode: :model)
+          end
         end
-        @attr_json_config
       end
+
 
       # Like `.new`, but translate store keys in hash
       def new_from_serializable(attributes = {})

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -40,12 +40,25 @@ module AttrJson
       #
       #       attr_json_config(default_container_attribute: "some_column")
       #    end
+      # TODO make Model match please.
       def attr_json_config(new_values = {})
-        @attr_json_config ||= Config.new(mode: :record)
         if new_values.present?
-          @attr_json_config = @attr_json_config.merge(new_values)
+          # get one without new values, then merge new values into it, and
+          # set it locally for this class.
+          @attr_json_config = attr_json_config.merge(new_values)
+        else
+          if instance_variable_defined?("@attr_json_config")
+            # we have a custom one for this class, return it.
+            @attr_json_config
+          elsif superclass.respond_to?(:attr_json_config)
+            # return superclass without setting it locally, so changes in superclass
+            # will continue effecting us.
+            superclass.attr_json_config
+          else
+            # no superclass, no nothing, set it to blank one.
+            @attr_json_config = Config.new(mode: :record)
+          end
         end
-        @attr_json_config
       end
 
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe AttrJson::Record do
     end
     describe ":allow" do
       before do
-        klass.attr_json_unknown_key = :allow
+        klass.attr_json_config(unknown_key: :allow)
       end
       it "allows" do
         instance.assign_attributes(attributes)
@@ -101,7 +101,7 @@ RSpec.describe AttrJson::Record do
     end
     describe ":strip" do
       before do
-        klass.attr_json_unknown_key = :strip
+        klass.attr_json_config(unknown_key: :strip)
       end
       it "strips" do
         instance.assign_attributes(attributes)

--- a/spec/record/subclasses_spec.rb
+++ b/spec/record/subclasses_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "subclassing" do
       self.table_name = "products"
 
       include AttrJson::Record
+      attr_json_config(default_container_attribute: "other_attributes")
 
       attr_json :parent_str, :string
       attr_json :parent_int, :integer
@@ -21,6 +22,7 @@ RSpec.describe "subclassing" do
   describe "parent class" do
     let(:registry_definitions) { parent_class.attr_json_registry.definitions }
 
+
     it "has only it's own attr_jsons" do
       expect(registry_definitions.collect(&:name)).to eq [:parent_str, :parent_int]
     end
@@ -32,5 +34,28 @@ RSpec.describe "subclassing" do
     it "has inherited attr_json's and it's own" do
       expect(registry_definitions.collect(&:name)).to eq [:parent_str, :parent_int, :child_str]
     end
+
+    it "inherits attr_json_config" do
+      expect(sub_class.attr_json_config.default_container_attribute).to eq "other_attributes"
+    end
+
+    describe "override config" do
+      let!(:sub_class) do
+        Class.new(parent_class) do
+          attr_json_config(default_container_attribute: "json_attributes")
+
+          attr_json :child_str, :string
+        end
+      end
+
+      it "subclass has overridden" do
+        expect(sub_class.attr_json_config.default_container_attribute).to eq "json_attributes"
+      end
+      it "parent class has original" do
+        expect(parent_class.attr_json_config.default_container_attribute).to eq "other_attributes"
+      end
+    end
+
   end
+
 end

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -483,7 +483,7 @@ RSpec.describe AttrJson::Record do
           include AttrJson::Record
           self.table_name = "products"
 
-          self.default_json_container_attribute = :other_attributes
+          self.attr_json_config(default_container_attribute: :other_attributes)
 
           attr_json :value, :string
         end
@@ -521,7 +521,7 @@ RSpec.describe AttrJson::Record do
           include AttrJson::Record
           self.table_name = "products"
 
-          self.default_json_container_attribute = :other_attributes
+          self.attr_json_config(default_container_attribute: :other_attributes)
           attr_json :foo, :string
           attr_json :bar, :string
 


### PR DESCRIPTION
single config method added to classes, `attr_json_config` which is used for reads and writes, writes replace config object with a new one with merged changes, the config object is actually immutable, to prevent class attribute inheritance confusion.

Closes #19