### PR TITLE
Track defaults as a change to container attribute

### DIFF
--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -74,6 +74,9 @@ module AttrJson
         # only if it hasn't already been done. WARNING we are using internal
         # Rails API here, but only way to do this lazily, which I thought was
         # worth it. On the other hand, I think .attribute is idempotent, maybe we don't need it...
+        #
+        # We set default to empty hash, because that 'tricks' AR into knowing any
+        # application of defaults is a change that needs to be saved.
         unless attributes_to_define_after_schema_loads[container_attribute.to_s] &&
                attributes_to_define_after_schema_loads[container_attribute.to_s].first.is_a?(AttrJson::Type::ContainerAttribute)
             attribute container_attribute.to_sym, AttrJson::Type::ContainerAttribute.new(self, container_attribute)

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -113,7 +113,7 @@ module AttrJson
                attributes_to_define_after_schema_loads[container_attribute.to_s].first.model == self
            # If this is already defined, but was for superclass, we need to define it again for
            # this class.
-           attribute container_attribute.to_sym, AttrJson::Type::ContainerAttribute.new(self, container_attribute), default: -> {}
+           attribute container_attribute.to_sym, AttrJson::Type::ContainerAttribute.new(self, container_attribute), default: -> { {} }
         end
 
         self.attr_json_registry = attr_json_registry.with(

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -79,7 +79,7 @@ module AttrJson
         # application of defaults is a change that needs to be saved.
         unless attributes_to_define_after_schema_loads[container_attribute.to_s] &&
                attributes_to_define_after_schema_loads[container_attribute.to_s].first.is_a?(AttrJson::Type::ContainerAttribute)
-            attribute container_attribute.to_sym, AttrJson::Type::ContainerAttribute.new(self, container_attribute)
+            attribute container_attribute.to_sym, AttrJson::Type::ContainerAttribute.new(self, container_attribute), default: -> {}
         end
 
         self.attr_json_registry = attr_json_registry.with(

--- a/lib/attr_json/record/dirty.rb
+++ b/lib/attr_json/record/dirty.rb
@@ -137,20 +137,20 @@ module AttrJson
         end
 
         def saved_changes
-          saved_changes = model.saved_changes
-          return {} if saved_changes == {}
+          original_saved_changes = model.saved_changes
+          return {} if original_saved_changes == {}
 
           json_attr_changes = registry.definitions.collect do |definition|
-            if container_change = saved_changes[definition.container_attribute]
-              old_v = container_change[0][definition.store_key]
-              new_v = container_change[1][definition.store_key]
+            if container_change = original_saved_changes[definition.container_attribute]
+              old_v = container_change.dig(0, definition.store_key)
+              new_v = container_change.dig(1, definition.store_key)
               if old_v != new_v
                 [ definition.name.to_s, formatted_before_after(old_v, new_v, definition) ]
               end
             end
           end.compact.to_h
 
-          prepared_changes(json_attr_changes, saved_changes)
+          prepared_changes(json_attr_changes, original_saved_changes)
         end
 
         def saved_changes?
@@ -198,21 +198,21 @@ module AttrJson
         end
 
         def changes_to_save
-          changes_to_save = model.changes_to_save
+          original_changes_to_save = model.changes_to_save
 
-          return {} if changes_to_save == {}
+          return {} if original_changes_to_save == {}
 
           json_attr_changes = registry.definitions.collect do |definition|
-            if container_change = changes_to_save[definition.container_attribute]
-              old_v = container_change[0][definition.store_key]
-              new_v = container_change[1][definition.store_key]
+            if container_change = original_changes_to_save[definition.container_attribute]
+              old_v = container_change.dig(0, definition.store_key)
+              new_v = container_change.dig(1, definition.store_key)
               if old_v != new_v
                 [ definition.name.to_s, formatted_before_after(old_v, new_v, definition) ]
               end
             end
           end.compact.to_h
 
-          prepared_changes(json_attr_changes, changes_to_save)
+          prepared_changes(json_attr_changes, original_changes_to_save)
         end
 
         def has_changes_to_save?

--- a/lib/attr_json/record/dirty.rb
+++ b/lib/attr_json/record/dirty.rb
@@ -138,7 +138,7 @@ module AttrJson
 
         def saved_changes
           original_saved_changes = model.saved_changes
-          return {} if original_saved_changes == {}
+          return {} if original_saved_changes.blank?
 
           json_attr_changes = registry.definitions.collect do |definition|
             if container_change = original_saved_changes[definition.container_attribute]
@@ -200,7 +200,7 @@ module AttrJson
         def changes_to_save
           original_changes_to_save = model.changes_to_save
 
-          return {} if original_changes_to_save == {}
+          return {} if original_changes_to_save.blank?
 
           json_attr_changes = registry.definitions.collect do |definition|
             if container_change = original_changes_to_save[definition.container_attribute]

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -655,6 +655,12 @@ RSpec.describe AttrJson::Record do
             end
           end
 
+          it "registers container as changed because of defaults" do
+            # even though we made no changes, we want defaults to count as changes? We think?
+            # https://github.com/jrochkind/attr_json/issues/26
+            expect(instance.json_attributes_changed?).to be true
+          end
+
           it "is all good" do
             expect(instance.value).to eq("value default")
             expect(instance.json_attributes).to eq("_store_key" => "value default")

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -669,6 +669,16 @@ RSpec.describe AttrJson::Record do
             instance.other_attributes = {}
             expect(instance.other_attributes).to eq("_store_key" => "other value default")
           end
+
+          it "saves defaults when they are the only changes" do
+            instance.save!
+            # better way to get what's really in the db skipping model?
+            saved_data = ActiveRecord::Base.connection.execute("select * from products where id = #{instance.id}").to_a.first
+            expect(saved_data["json_attributes"]).to be_present
+            expect(JSON.parse(saved_data["json_attributes"])).to eq("_store_key"=>"value default")
+            expect(saved_data["other_attributes"]).to be_present
+            expect(JSON.parse(saved_data["other_attributes"])).to eq("_store_key"=>"other value default")
+          end
         end
       end
     end


### PR DESCRIPTION
Closes #26

By fixing AttrJson::Type::ContainerAttribute to properly account for defaults in changed_in_place?, which makes it more correct anyway. 

And adding an empty hash default to AR attribute for container attributes. This gets AR change-tracking to realize that the defaults being applied constitute a change, and the container column needs to be saved. Couldn't figure out another way to get to relevant AR change tracking method API more directly, from the places I am. 

Turns out attr_json even before this change wouldn't let you save nil/null in a container attribute column, it insisted on empty hash. Which is probably fine, and any rate is not a regression here.