### PR TITLE
attr_json_accepts_nested_attributes_for has special implementation for array of primitives

### DIFF
--- a/lib/attr_json/nested_attributes.rb
+++ b/lib/attr_json/nested_attributes.rb
@@ -29,6 +29,11 @@ module AttrJson
       # * _allow_destroy_, no such option. Effectively always true, doesn't make sense to try to gate this with our implementation.
       # * _update_only_, no such option. Not really relevant to this architecture where you're embedded models have no independent existence.
       #
+      # If called on an array of 'primitive' (not AttrJson::Model) objects, it will do a kind of weird
+      # thing where it creates an `#{attribute_name}_attributes=` method that does nothing
+      # but filter out empty strings and nil values. This can be convenient in hackily form
+      # handling array of primitives, see guide doc on forms.
+      #
       # @overload attr_json_accepts_nested_attributes_for(define_build_method: true, reject_if: nil, limit: nil)
       #   @param define_build_method [Boolean] Default true, provide `build_attribute_name`
       #     method that works like you expect. [Cocoon](https://github.com/nathanvda/cocoon),
@@ -74,7 +79,8 @@ module AttrJson
             end
           end
 
-          if options[:define_build_method]
+          # No build method for our wacky array of primitive type.
+          if options[:define_build_method] && !(attr_def.array_type? && attr_def.type.base_type_primitive?)
             _attr_jsons_module.module_eval do
               build_method_name = "build_#{attr_name.to_s.singularize}"
               if method_defined?(build_method_name)

--- a/lib/attr_json/type/array.rb
+++ b/lib/attr_json/type/array.rb
@@ -41,6 +41,12 @@ module AttrJson
         ]
       end
 
+      # Hacky, hard-coded classes, but used in our weird primitive implementation in NestedAttributes,
+      # better than putting the conditionals there
+      def base_type_primitive?
+        !(base_type.is_a?(AttrJson::Type::Model) || base_type.is_a?(AttrJson::Type::PolymorphicModel))
+      end
+
       protected
       def convert_to_array(value)
         if value.kind_of?(Hash)

--- a/spec/nested_attributes/nested_attributes_spec.rb
+++ b/spec/nested_attributes/nested_attributes_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe AttrJson::NestedAttributes do
 
       attr_json :one_model, model_class_type
       attr_json :many_models, model_class_type, array: true
+      attr_json :array_of_strings, :string, array: true
 
-      attr_json_accepts_nested_attributes_for :one_model, :many_models
+      attr_json_accepts_nested_attributes_for :one_model, :many_models, :array_of_strings
     end
   end
   let(:instance) { klass.new }
@@ -167,6 +168,34 @@ RSpec.describe AttrJson::NestedAttributes do
         )
         expect(instance.many_models).to eq [model_class.new(str: "yep")]
       end
+    end
+  end
+
+  describe "array of primitives" do
+    let(:setter) { :array_of_strings= }
+
+    it "should_define_an_attribute_writer_method" do
+      expect(instance).to respond_to setter
+    end
+
+    it "assign an array of strings on update" do
+      instance.update({ array_of_strings_attributes: ["one", "two", "three"] })
+
+      expect(instance.array_of_strings).to be_present
+      expect(instance.array_of_strings).to eq(["one", "two", "three"])
+    end
+
+    it "removes nils and empty strings on update" do
+      instance.update({ array_of_strings_attributes: ["", "one", nil, "two", "", "", "three"] })
+
+      expect(instance.array_of_strings).to be_present
+      expect(instance.array_of_strings).to eq(["one", "two", "three"])
+    end
+
+    it "assign an empty array" do
+      instance.update({ array_of_strings_attributes: [] })
+
+      expect(instance.array_of_strings).to eq([])
     end
   end
 


### PR DESCRIPTION
That simply filters out empty strings and nil values.

This can be convenient in form handling. See forms.md doc.

It is definitely getting a bit convoluted... but it works.