### PR TITLE
raise on bad model cast

### DIFF
--- a/lib/attr_json/type/model.rb
+++ b/lib/attr_json/type/model.rb
@@ -8,6 +8,8 @@ module AttrJson
     # but normally that's only done in AttrJson::Model.to_type, there isn't
     # an anticipated need to create from any other place.
     class Model < ::ActiveModel::Type::Value
+      class BadCast < ArgumentError ; end
+
       attr_accessor :model
       def initialize(model)
         #TODO type check, it really better be a AttrJson::Model. maybe?
@@ -34,10 +36,11 @@ module AttrJson
           # TODO Maybe we ought not to do this on #to_h?
           model.new_from_serializable(v.to_h)
         else
-          # Bad input? Most existing ActiveModel::Types seem to decide
-          # either nil, or a base value like the empty string. They don't
-          # raise. So we won't either, just nil.
-          nil
+          # Bad input. Originally we were trying to return nil, to be like
+          # existing ActiveRecord which kind of silently does a basic value
+          # with null input. But that ended up making things confusing, let's
+          # just raise.
+          raise BadCast.new("Can not cast from #{v.inspect} to #{self.type}")
         end
       end
 

--- a/spec/record_with_model_spec.rb
+++ b/spec/record_with_model_spec.rb
@@ -140,18 +140,11 @@ RSpec.describe AttrJson::Record do
   end
 
   describe "with weird input" do
-    it "ignores input" do
+    it "raises" do
       # this SEEMS to be consistent with what other ActiveModel::Types do...
-      instance.model = "this is not a model"
-      expect(instance.model).to be nil
-
-      # i'd be fine if it set key to nil, but current implementation
-      # seems to not set key at all, which is also fine.
-      expect(instance.json_attributes).to eq({})
-
-      instance.save!
-
-      expect(instance.json_attributes_before_type_cast).to eq("{}")
+      expect {
+        instance.model = "this is not a model"
+      }.to raise_error(AttrJson::Type::Model::BadCast)
     end
   end
 


### PR DESCRIPTION
We had been trying to return nil, since this seemed consistent with existing ActiveRecord primitive values, which kind of go to some base value on a bad cast.

But this ended up making errors in our real client code confusing and hard to debug. Let's try raising early.

Note this means we'll raise on trying to fetch something from the DB with data that can't be cast too, we may have to revisit that.