### PR TITLE
Arbitrary hash docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ You can register your custom `ActiveModel::Type::Value` in a Rails initializer o
 ActiveRecord::Type.register(:my_type, MyActiveModelTypeSubclass)
 ```
 
+## Storing arbitrary depth hashes
+
+Arbitrary depth hashes can be stored within attributes by using the rails built in ActiveModel::Type::Value as the attribute type. This type performs a no-op on serialize/deserialize (to and from the database).
+
+Please note this will not perform any validations, and should be used with care with data from the outside world.
+
+```
+class MyModel < ActiveRecord::Base
+  include AttrJson::Record
+
+  attr_json :arbitrary_hash, ActiveModel::Type::Value.new
+end
+
+```
+
 <a name="querying"></a>
 ## Querying
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ ActiveRecord::Type.register(:my_type, MyActiveModelTypeSubclass)
 
 ## Storing arbitrary depth hashes
 
-Arbitrary depth hashes can be stored within attributes by using the rails built in ActiveModel::Type::Value as the attribute type. This type performs a no-op on serialize/deserialize (to and from the database).
+Arbitrary depth hashes can be stored within attributes by using the rails built in `ActiveModel::Type::Value` as the attribute type. This type performs a no-op on serialize/deserialize (to and from the database).
 
 Please note this will not perform any validations, and should be used with care with data from the outside world.
 

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
 
-require 'pry'
-
 RSpec.describe AttrJson::Record do
   let(:klass) do
     Class.new(ActiveRecord::Base) do

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+require 'pry'
+
 RSpec.describe AttrJson::Record do
   let(:klass) do
     Class.new(ActiveRecord::Base) do
@@ -34,7 +36,8 @@ RSpec.describe AttrJson::Record do
     [:boolean, true, "t"],
     [:date, Date.parse("2017-04-28"), "2017-04-28"],
     [:datetime, DateTime.parse("2017-04-04 04:45:00").to_time, "2017-04-04T04:45:00Z"],
-    [:float, 45.45, "45.45"]
+    [:float, 45.45, "45.45"],
+    [:json, {"a" => "b", "b" => {"c" => "d"}}, {a: "b", b: {"c" => "d"}}]
   ].each do |type, cast_value, uncast_value|
     describe "for primitive type #{type}" do
       let(:klass) do


### PR DESCRIPTION
Documentation update to explain how to use arbitrary hashes in a json attribute.

There are no tests to cover this functonality, and it is probably dangerous.

Any thoughts?