### PR TITLE
update documentation for allowing arbitrary depth hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ You can register your custom `ActiveModel::Type::Value` in a Rails initializer o
 ActiveRecord::Type.register(:my_type, MyActiveModelTypeSubclass)
 ```
 
+## Storing arbitrary depth hashes
+
+Arbitrary depth hashes can be stored within attributes by using the rails built in `ActiveModel::Type::Value` as the attribute type. This type performs a no-op on serialize/deserialize (to and from the database).
+
+Please note this will not perform any validations, and should be used with care with data from the outside world.
+
+```
+class MyModel < ActiveRecord::Base
+  include AttrJson::Record
+
+  attr_json :arbitrary_hash, ActiveModel::Type::Value.new
+end
+
+```
+
 <a name="querying"></a>
 ## Querying
 


### PR DESCRIPTION
Documentation update to explain how to use arbitrary hashes in a json attribute.

There are no tests to cover this functonality, and it is probably dangerous.

Any thoughts?