### PR TITLE
feature: query attribute

### DIFF
--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -37,7 +37,7 @@ module AttrJson
       when true        then true
       when false, nil  then false
       else
-        if !type_for_attribute(attr_name) { false }
+        if !self.class.attr_json_registry.type_for_attribute(store_key) { false }
           if Numeric === value || value !~ /[^0-9]/
             !value.to_i.zero?
           else

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe AttrJson::Record do
   let(:instance_custom) { klass_with_custom.new }
 
   [
-    [:integer, 12, "12"],
-    [:string, "12", 12],
-    [:decimal, BigDecimal("10.01"), "10.0100"],
-    [:boolean, true, "t"],
-    [:date, Date.parse("2017-04-28"), "2017-04-28"],
-    [:datetime, DateTime.parse("2017-04-04 04:45:00").to_time, "2017-04-04T04:45:00Z"],
-    [:float, 45.45, "45.45"]
-  ].each do |type, cast_value, uncast_value|
+    [:integer, 12, "12", 0],
+    [:string, "12", 12, ""],
+    [:decimal, BigDecimal("10.01"), "10.0100", 0],
+    [:boolean, true, "t", false],
+    [:date, Date.parse("2017-04-28"), "2017-04-28", nil],
+    [:datetime, DateTime.parse("2017-04-04 04:45:00").to_time, "2017-04-04T04:45:00Z", nil],
+    [:float, 45.45, "45.45", 0]
+  ].each do |type, cast_value, uncast_value, falsey_value|
     describe "for primitive type #{type}" do
       let(:klass) do
         Class.new(ActiveRecord::Base) do
@@ -66,6 +66,12 @@ RSpec.describe AttrJson::Record do
 
         expect(instance.value).to eq(cast_value)
         expect(instance.json_attributes["value"]).to eq(cast_value)
+      end
+      it "generates a query method #{type}?" do
+        instance.value = cast_value
+        expect(instance.value?).to be(true)
+        instance.value = falsey_value
+        expect(instance.value?).to be(false)
       end
     end
   end


### PR DESCRIPTION
Hi! Thanks for the gem!
I've added query attributes that behave similarly to ActiveRecord implementation.
Here is an example of the intended usage:

```ruby
class ExampleModel < ActiveRecord::Base
  attr_json :my_string, :string
  attr_json :my_int, :integer
  attr_json :my_bool, :boolean
end

e = ExampleModel.new

e.my_string = 'foobar'
e.my_string? # true
e.my_string = ''
e.my_string? # false

e.my_int = 1
e.my_int? # true
e.my_int = 0
e.my_int? # false

e.my_bool = true
e.my_bool? # true
e.my_bool = false
e.my_bool? # false
```