### PR TITLE
feature: Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.6.2
+
+RUN apt-get update -qq \
+    && apt-get upgrade -y --no-install-recommends \
+      build-essential \
+      postgresql-client \
+    && apt-get clean autoclean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt /var/lib/cache /var/lib/log
+
+RUN gem install bundler
+
+RUN mkdir -p /app/
+WORKDIR /app/
+
+# Add bundle entry point to handle bundle cache
+COPY ./docker-entrypoint.sh /usr/local/bin
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["/app/bin/rspec"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "2.4"
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - PG_HOST=postgres
+    volumes:
+      - bundle_cache:/usr/local/bundle
+      - .:/app
+    links:
+      - postgres
+
+  postgres:
+    image: postgres:9.6
+
+volumes:
+  bundle_cache:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Ensure all gems installed on start
+bundle check || bundle install --jobs 3 --retry 20
+
+# Finally call command issued to the docker service
+exec "$@"

--- a/spec/internal/config/database.yml
+++ b/spec/internal/config/database.yml
@@ -7,11 +7,15 @@
 
 test:
   adapter: postgresql
+  host: <%= ENV['PG_HOST'] || 'localhost' %>
+  username: <%= ENV['PG_USER'] || 'postgres' %>
   encoding: unicode
   database: <%= ENV['RAILS_PG_DB'] || "attr_json_project_test" %>
 
 # Warning, combustion will drop your dev database too....
 development:
   adapter: postgresql
+  host: <%= ENV['PG_HOST'] || 'localhost' %>
+  username: <%= ENV['PG_USER'] || 'postgres' %>
   encoding: unicode
   database: <%= ENV['RAILS_PG_DB'] || "attr_json_project_dev_throwaway" %>


### PR DESCRIPTION
This PR adds basic Docker configuration for developing this gem locally.

In a brand new computer all you have to do is install Docker, clone the repo and run:
```sh
docker-compose up
```

It downloads a recent Ruby image, runs `bundle install`, installs Postgres and runs all the specs! 😀 