### PR TITLE
Provide query methods for attr_json attributes, like AR's for ordinary attributes

### DIFF
--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -28,15 +28,15 @@ RSpec.describe AttrJson::Record do
   let(:instance_custom) { klass_with_custom.new }
 
   [
-    [:integer, 12, "12"],
-    [:string, "12", 12],
-    [:decimal, BigDecimal("10.01"), "10.0100"],
-    [:boolean, true, "t"],
-    [:date, Date.parse("2017-04-28"), "2017-04-28"],
-    [:datetime, DateTime.parse("2017-04-04 04:45:00").to_time, "2017-04-04T04:45:00Z"],
-    [:float, 45.45, "45.45"],
-    [ActiveRecord::Type::Value.new, {"a" => {"b" => "c"}}, {"a" => {"b" => "c"}}]
-  ].each do |type, cast_value, uncast_value|
+    [:integer, 12, "12", 0],
+    [:string, "12", 12, ""],
+    [:decimal, BigDecimal("10.01"), "10.0100", 0],
+    [:boolean, true, "t", false],
+    [:date, Date.parse("2017-04-28"), "2017-04-28", nil],
+    [:datetime, DateTime.parse("2017-04-04 04:45:00").to_time, "2017-04-04T04:45:00Z", nil],
+    [:float, 45.45, "45.45", 0],
+    [ActiveRecord::Type::Value.new, {"a" => {"b" => "c"}}, {"a" => {"b" => "c"}}, nil]
+  ].each do |type, cast_value, uncast_value, falsey_value|
     describe "for primitive type #{type}" do
       let(:klass) do
         Class.new(ActiveRecord::Base) do
@@ -67,6 +67,12 @@ RSpec.describe AttrJson::Record do
 
         expect(instance.value).to eq(cast_value)
         expect(instance.json_attributes["value"]).to eq(cast_value)
+      end
+      it "generates a query method #{type}?" do
+        instance.value = cast_value
+        expect(instance.value?).to be(true)
+        instance.value = falsey_value
+        expect(instance.value?).to be(false)
       end
     end
   end


### PR DESCRIPTION
If you do `attr_json :something, :string`, you should get a `#something?` instance method generated, similar to the query methods AR generates for ordinary attributes


Based on @giovannibonetti 's code in #58, with some changes. Closes #58, thanks @giovannibonetti for the contribution!

Sadly we could not re-use Rails code here, becuase the built-in method assumes attribute
can be obtained with `self[attr_name]`, which you can not with attr_json (is that bad?), as
well as `self.class.columns_hash[attr_name]` which you definitely can not (which is probably not bad),
and has no way to use the value-translation semantics independently of that. May be a problem if
ActiveRecord changes it's query method semantics in the future, will have to be sync'd here.