### PR TITLE
generate dirty tracking method for each field

### DIFF
--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -186,6 +186,18 @@ module AttrJson
             # implementation of `query_store_attribute` is based on Rails `query_attribute` implementation
             AttrJson::Record.attr_json_query_method(self, name)
           end
+
+          define_method("#{name}_changed?") do
+            if !defined?(attr_json_changes)
+              raise NotImplementedError, <<~TXT
+                Please add the following line to #{self.class}:
+                include AttrJson::Record::Dirty
+              TXT
+            end
+
+            # see lib/attr_json/record/dirty.rb
+            attr_json_changes.changes_to_save[name.to_s].present?
+          end
         end
 
         # Default attr_json_accepts_nested_attributes_for values

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -196,7 +196,7 @@ module AttrJson
             end
 
             # see lib/attr_json/record/dirty.rb
-            attr_json_changes.changes_to_save[name.to_s].present?
+            attr_json_changes.send("will_save_change_to_#{name}?")
           end
         end
 

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -68,11 +68,20 @@ RSpec.describe AttrJson::Record do
         expect(instance.value).to eq(cast_value)
         expect(instance.json_attributes["value"]).to eq(cast_value)
       end
-      it "generates a query method #{type}?" do
+      it "generates a query method value?" do
         instance.value = cast_value
         expect(instance.value?).to be(true)
         instance.value = falsey_value
         expect(instance.value?).to be(false)
+      end
+      it "generates a dirty tracking method value_changed?" do
+        expect { instance.value_changed? }.to raise_error(NotImplementedError)
+        klass.include AttrJson::Record::Dirty
+        expect(instance.value_changed?).to be(false)
+        instance.value = cast_value
+        expect(instance.value_changed?).to be(true)
+        instance.value = nil
+        expect(instance.value_changed?).to be(false)
       end
     end
   end


### PR DESCRIPTION
I was working with the gem in my project when I noticed all my specs that relied on methods "field_changed?" were failing. Then I realized that, although these methods are defined, they are completely wrong since their implementation comes from ActiveRecord instead of `attr_json`.

Hence I added one possible implementation to overwrite ActiveRecord's implementation with a correct one based on [lib/attr_json/record/dirty.rb](https://github.com/jrochkind/attr_json/blob/master/lib/attr_json/record/dirty.rb). There is probably an easier way to implement it, but at least it seems to be working now.