### PR TITLE
Minor improvements to better sync with Rails attributes

### DIFF
--- a/lib/attr_json/config.rb
+++ b/lib/attr_json/config.rb
@@ -3,10 +3,15 @@ module AttrJson
   # and rails class_attribute. Instead, you set to new Config object
   # changed with {#merge}.
   class Config
-    RECORD_ALLOWED_KEYS = %i{default_container_attribute default_accepts_nested_attributes}
+    RECORD_ALLOWED_KEYS = %i{
+      default_container_attribute
+      default_rails_attribute
+      default_accepts_nested_attributes
+    }
     MODEL_ALLOWED_KEYS = %i{unknown_key}
     DEFAULTS = {
       default_container_attribute: "json_attributes",
+      default_rails_attribute: false,
       unknown_key: :raise
     }
 

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -785,16 +785,23 @@ RSpec.describe AttrJson::Record do
             include AttrJson::Record
 
             self.table_name = "products"
-            attr_json :str, :string, array: true, rails_attribute: true
+            attr_json :str, :string, array: true, rails_attribute: true, default: 'foo'
           end
         end
         it "registers attribute and type" do
           expect(instance.attributes.keys).to include("str")
+          expect(instance.attributes["str"]).to eq ['foo']
           expect(instance.type_for_attribute("str")).to be_kind_of(AttrJson::Type::Array)
           expect(instance.type_for_attribute("str").base_type).to be_kind_of(ActiveModel::Type::String)
         end
         it "still has our custom methods on top" do
           skip "gah, how do we test this"
+        end
+
+        it 'syncs Rails attributes and default values after find' do
+          instance.save
+          found_record = klass.find(instance.id)
+          expect(found_record.attributes["str"]).to eq ['foo']
         end
       end
     end


### PR DESCRIPTION
Coming to this gem from `jsonb_accessor`, I realized that syncing with Rails attributes was really necessary. I had to use this hack to load the attributes to record after initialization. Is this something that would be interesting to have? 