### PR TITLE
Ensure AttrJson default configs can be set globally

### DIFF
--- a/lib/attr_json/config.rb
+++ b/lib/attr_json/config.rb
@@ -1,4 +1,20 @@
 module AttrJson
+  DEFAULTS = {
+    default_container_attribute: "json_attributes",
+    unknown_key: :raise
+  }
+  @@config = DEFAULTS
+
+  def self.config
+    @@config = yield(@@config) if block_given?
+    @@config
+  end
+
+  def self.reset
+    @@config = DEFAULTS
+  end
+
+
   # Intentionally non-mutable, to avoid problems with subclass inheritance
   # and rails class_attribute. Instead, you set to new Config object
   # changed with {#merge}.
@@ -26,7 +42,7 @@ module AttrJson
       valid_keys = mode == :record ? RECORD_ALLOWED_KEYS : MODEL_ALLOWED_KEYS
       options.assert_valid_keys(valid_keys)
 
-      options.reverse_merge!(DEFAULTS.slice(*valid_keys))
+      options.reverse_merge!(AttrJson.config.slice(*valid_keys))
 
       @attributes = options
     end

--- a/lib/attr_json/model.rb
+++ b/lib/attr_json/model.rb
@@ -257,6 +257,9 @@ module AttrJson
       false
     end
 
+
+    # TODO: write an #inspect that pretty prints the attribute names and values.
+
     private
 
     def _attr_json_write(key, value)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -157,4 +157,8 @@ RSpec.configure do |config|
   config.before do
     DatabaseCleaner.clean_with(:truncation)
   end
+
+  config.after do
+    AttrJson.reset
+  end
 end


### PR DESCRIPTION
I use a different name for my jsonb column. Having to specify this everywhere I use `attr_json` was a drag, so I created a global configuration to specify default value for this column.