### PR TITLE
Support MySQL JSON

### DIFF
--- a/lib/attr_json.rb
+++ b/lib/attr_json.rb
@@ -1,7 +1,6 @@
 require "attr_json/version"
 
 require "active_record"
-require "active_record/connection_adapters/postgresql_adapter"
 
 require 'attr_json/config'
 require 'attr_json/record'


### PR DESCRIPTION
MySQL supports JSON fields since 5.7.8.

Your gem actually does support MySQL JSON fields at least for storage (I did not check querying).
So there is no need to restrict it to PostgreSQL-only