### PR TITLE
test under MRI 2.6.5 too, for Rails 5.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache: bundler
 rvm:
   - 2.4.5
   - 2.5.3
+  - 2.6.5
 gemfile:
   - gemfiles/rails_5_0.gemfile
   - gemfiles/rails_5_1.gemfile
@@ -24,5 +25,12 @@ matrix:
   exclude:
     - gemfile: gemfiles/rails_edge_6.gemfile
       rvm: 2.4.5
+    - gemfile: gemfiles/rails_edge_6.gemfile
+      rvm: 2.5.3
     - gemfile: gemfiles/rails_6_0.gemfile
       rvm: 2.4.5
+    - gemfile: gemfiles/rails_5_1.gemfile
+      rvm: 2.6.5
+    - gemfile: gemfiles/rails_5_0.gemfile
+      rvm: 2.6.5
+


### PR DESCRIPTION
We don't want to REMOVE any old ruby versions without a major version release, cause we want to promise it still works under those. So we have a lot of versions tested under now. But we'll only add the new one for Rails 5.2+, since earlier versions are out of support for Rails team anyway.