### PR TITLE
Avoid Time#=~ deprecation

### DIFF
--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -47,7 +47,7 @@ module AttrJson
       when false, nil, ActiveModel::Type::Boolean::FALSE_VALUES
         false
       else
-        if value.respond_to?(:to_i) && ( Numeric === value || value !~ /[^0-9]/ )
+        if value.respond_to?(:to_i) && ( Numeric === value || value.to_s !~ /[^0-9]/ )
           !value.to_i.zero?
         elsif value.respond_to?(:zero?)
           !value.zero?


### PR DESCRIPTION
I _think_ this is what the code was really meaning to do. This is all somewhat mysterious, alas.

In ruby 2.7.0, we got:

    /Users/jrochkind/code/attr_json/lib/attr_json/record.rb:50: warning: deprecated Object#=~ is called on Time; it always returns nil

On `rspec ./spec/record_spec.rb:73`