### PR TITLE
AttrJson::Model#== requires exact same class, not sub-class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Documented and tested support for using ActiveRecord serialize to map one AttrJson::Model
 to an entire column on it's own. https://github.com/jrochkind/attr_json/pull/89
 
+### Changed
+
+* AttrJson::Model#== now requires same class for equality. And doesn't raise on certain arguments. https://github.com/jrochkind/attr_json/pull/90 Thanks @caiofilipemr for related bug report.
+
 ## [1.1.0](https://github.com/jrochkind/attr_json/compare/v1.0.0...v1.1.0)
 
 ### Added

--- a/lib/attr_json/model.rb
+++ b/lib/attr_json/model.rb
@@ -240,12 +240,9 @@ module AttrJson
     end
 
     # Two AttrJson::Model objects are equal if they are the same class
-    # or one is a subclass of the other, AND their #attributes are equal.
-    # TODO: Should we allow subclasses to be equal, or should they have to be the
-    # exact same class?
+    # AND their #attributes are equal.
     def ==(other_object)
-      (other_object.is_a?(self.class) || self.is_a?(other_object.class)) &&
-      other_object.attributes == self.attributes
+      other_object.class == self.class && other_object.attributes == self.attributes
     end
 
     # ActiveRecord objects [have a](https://github.com/rails/rails/blob/v5.1.5/activerecord/lib/active_record/nested_attributes.rb#L367-L374)

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -203,5 +203,26 @@ RSpec.describe AttrJson::Record do
     end
   end
 
+  describe "#==" do
+    let(:klass) do
+      Class.new do
+        include AttrJson::Model
 
+        attr_json :str_one, :string
+      end
+    end
+
+    it "does not equal with different values" do
+      expect(instance == klass.new(str_one: "different")).to eq(false)
+    end
+
+    it "does equal with same values" do
+      expect(instance == klass.new).to eq(true)
+      expect(klass.new(str_one: "value") == klass.new(str_one: "value")).to eq(true)
+    end
+
+    it "does not equal some random object" do
+      expect(instance == Object.new).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Better semantics. Avoids potential for bugs like the one @caiofilipemr  kindly reported in #84.

With tests of the == method.

While if we're being honest this is technically a backwards incompat, we're going to call it a bug fix, that didn't make any sense, and I doubt anyone was relying on it.