### PR TITLE
Separate object to serve as AR serialization coder from our ActiveModel::Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Documented and tested support for using ActiveRecord serialize to map one AttrJson::Model
-to an entire column on it's own. https://github.com/jrochkind/attr_json/pull/89
+to an entire column on it's own. https://github.com/jrochkind/attr_json/pull/89 and
+https://github.com/jrochkind/attr_json/pull/93
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ in this case.
   attr_json :lang_and_value, LangAndValue.to_type, default: { lang: "en", value: "default" }
 ```
 
+
 ### Polymorphic model types
 
 There is some support for "polymorphic" attributes that can hetereogenously contain instances of different AttrJson::Model classes, see comment docs at [AttrJson::Type::PolymorphicModel](./lib/attr_json/type/polymorphic_model.rb).
@@ -335,6 +336,32 @@ MyTable.create(some_json_column: { some_int: 12 })
 
 # etc
 ```
+
+To avoid errors raised at inconvenient times, we recommend you set these settings to make 'bad'
+data turn into `nil`, consistent with most ActiveRecord types:
+
+```ruby
+class MyModel
+  include AttrJson::Model
+
+  attr_json_config(bad_cast: :as_nil, unknown_key: :strip)
+  # ...
+end
+```
+
+And/or define a setter method to cast, and raise early on data problems:
+
+```ruby
+class MyTable < ApplicationRecord
+  serialize :some_json_column, MyModel.to_serialization_coder
+
+  def some_json_column=(val)
+    super(   )
+  end
+end
+```
+
+Serializing a model to an entire json column is a relatively recent feature, please let us know how it's working for you.
 
 <a name="arbitrary-json-data"></a>
 ## Storing Arbitrary JSON data

--- a/README.md
+++ b/README.md
@@ -313,8 +313,8 @@ under different keys combined in a single json or jsonb column.
 But you may also want to have one AttrJson::Model class that serializes to map one model class, as
 a hash, to an entire json column on it's own.
 
-You can also use the standard [ActiveRecord serialization](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html)
-feature with AttrJson::Model#to_type to easily do that.
+`AttrJson::Model` can supply a simple coder for the [ActiveRecord serialization](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html)
+feature  to easily do that.
 
 ```ruby
 class MyModel
@@ -325,7 +325,7 @@ class MyModel
 end
 
 class MyTable < ApplicationRecord
-  serialize :some_json_column, MyModel.to_type
+  serialize :some_json_column, MyModel.to_serialization_coder
 end
 
 MyTable.create(some_json_column: MyModel.new(some_string: "string"))

--- a/lib/attr_json/serialization_coder_from_type.rb
+++ b/lib/attr_json/serialization_coder_from_type.rb
@@ -1,0 +1,40 @@
+module AttrJson
+
+  # A little wrapper to provide an object that provides #dump and #load method for use
+  # as a coder second-argument for [ActiveRecord Serialization](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html),
+  # that simply delegates to #serialize and #deserialize from a ActiveModel::Type object.
+  #
+  # Created to be used with an AttrJson::Model type (AttrJson::Type::Model), but hypothetically
+  # could be a shim from anything with serialize/deserialize to dump/load instead.
+  #
+  #    class ValueModel
+  #      include AttrJson::Model
+  #      attr_json :some_string, :string
+  #    end
+  #
+  #    class SomeModel < ApplicationRecord
+  #      serialize :some_json_column, ValueModel.to_serialize_coder
+  #    end
+  #
+  # Note when used with an AttrJson::Model, it will dump/load from a HASH, not a
+  # string. It assumes it's writing to a Json(b) column that wants/provides hashes,
+  # not strings.
+  class SerializationCoderFromType
+    attr_reader :type
+    def initialize(type)
+      @type = type
+    end
+
+    # Dump and load methods to support ActiveRecord Serialization
+    # too.
+    def dump(value)
+      type.serialize(value)
+    end
+
+    # Dump and load methods to support ActiveRecord Serialization
+    # too. https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html
+    def load(value)
+      type.deserialize(value)
+    end
+  end
+end

--- a/lib/attr_json/type/model.rb
+++ b/lib/attr_json/type/model.rb
@@ -53,7 +53,7 @@ module AttrJson
         elsif v.kind_of?(model)
           v.serializable_hash
         else
-          cast(v).serializable_hash
+          (cast_v = cast(v)) && cast_v.serializable_hash
         end
       end
 

--- a/lib/attr_json/type/model.rb
+++ b/lib/attr_json/type/model.rb
@@ -8,21 +8,6 @@ module AttrJson
     # but normally that's only done in AttrJson::Model.to_type, there isn't
     # an anticipated need to create from any other place.
     #
-    # ## ActiveRecord `serialize`
-    #
-    # This class also provides #dump and #load methods, so it can be used
-    # with ActiveRecord `serialize` feature, to map a single AttrJson::Model
-    # to a json/jsonb column.
-    # https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html
-    #
-    # class ValueModel
-    #   include AttrJson::Model
-    #   attr_json :some_string, :string
-    # end
-    #
-    # class SomeModel < ApplicationRecord
-    #   serialize :some_json_column, ValueModel.to_type
-    # end
     class Model < ::ActiveModel::Type::Value
       class BadCast < ArgumentError ; end
 
@@ -90,18 +75,6 @@ module AttrJson
             attr_def.serialize(attr_def.cast value)
           end
         }
-      end
-
-      # Dump and load methods to support ActiveRecord Serialization
-      # too. https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html
-      def dump(value)
-        serialize(value)
-      end
-
-      # Dump and load methods to support ActiveRecord Serialization
-      # too. https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html
-      def load(value)
-        deserialize(value)
       end
     end
   end

--- a/spec/single_serialized_model_attribute_spec.rb
+++ b/spec/single_serialized_model_attribute_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "AttrJson::Model with ActiveRecord serialize to one column" do
 
 
   let(:record_class) do
-    type_as_serializer = embedded_model_class.to_type
+    type_as_serializer = embedded_model_class.to_serialization_coder
 
     Class.new(ActiveRecord::Base) do
       self.table_name = "products"
@@ -84,7 +84,7 @@ RSpec.describe "AttrJson::Model with ActiveRecord serialize to one column" do
   end
 
 
-  xit "for non-castable primitive" do
+  it "for non-castable primitive", pending: "hard to get this working performantly" do
     expect {
       record_instance.other_attributes = 4
     }.to raise_error

--- a/spec/single_serialized_model_attribute_spec.rb
+++ b/spec/single_serialized_model_attribute_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe "AttrJson::Model with ActiveRecord serialize to one column" do
       record_instance.reload
       expect(record_instance.other_attributes).to be_nil
     end
+
+    it "registers in-place changes" do
+      record_instance.save!
+      expect(record_instance.other_attributes_changed?).to eq(false)
+
+      record_instance.other_attributes.str = "new value set in place"
+
+      expect(record_instance.other_attributes_changed?).to eq(true)
+    end
   end
 
 

--- a/spec/single_serialized_model_attribute_spec.rb
+++ b/spec/single_serialized_model_attribute_spec.rb
@@ -92,10 +92,34 @@ RSpec.describe "AttrJson::Model with ActiveRecord serialize to one column" do
     end
   end
 
-
   it "for non-castable primitive", pending: "hard to get this working performantly" do
     expect {
       record_instance.other_attributes = 4
-    }.to raise_error
+    }.to raise_error(StandardError)
+  end
+
+  describe "with nullify on bad cast settings" do
+    let(:embedded_model_class) do
+      Class.new do
+        include AttrJson::Model
+
+        attr_json_config(bad_cast: :as_nil, unknown_key: :strip)
+
+        attr_json :str, :string
+        attr_json :int, :integer
+      end
+    end
+
+    it "for a non-castable type" do
+      record_instance.other_attributes = 4
+      expect(record_instance.other_attributes).to eq(nil)
+      record_instance.save!
+    end
+
+    it "for unrecognized keys" do
+      record_instance.other_attributes = { no_such_key: "something" }
+      expect(record_instance.other_attributes).to eq(embedded_model_class.new)
+      record_instance.save!
+    end
   end
 end


### PR DESCRIPTION
In master/Rails 6.1, they wind up with conflicting APIs. This is better OO design anyway, that was a mistaken shortcut, keep everything clear this way.

Resolves #92