### PR TITLE
attr_json_config(bad_cast: :as_nil)

### DIFF
--- a/lib/attr_json/config.rb
+++ b/lib/attr_json/config.rb
@@ -4,7 +4,7 @@ module AttrJson
   # changed with {#merge}.
   class Config
     RECORD_ALLOWED_KEYS = %i{default_container_attribute default_accepts_nested_attributes}
-    MODEL_ALLOWED_KEYS = %i{unknown_key}
+    MODEL_ALLOWED_KEYS = %i{unknown_key bad_cast}
     DEFAULTS = {
       default_container_attribute: "json_attributes",
       unknown_key: :raise

--- a/lib/attr_json/model.rb
+++ b/lib/attr_json/model.rb
@@ -33,6 +33,17 @@ module AttrJson
   #          attr_json_config(unknown_key: :allow)
   #          #...
   #        end
+  #
+  # Similarly, trying to set a Model-valued attribute with an object that
+  # can't be cast to a Hash or Model at all will normally raise a
+  # AttrJson::Type::Model::BadCast error, but you can set config `bad_cast: :as_nil`
+  # to make it cast to nil, more like typical ActiveRecord cast.
+  #
+  #        class Something
+  #          include AttrJson::Model
+  #          attr_json_config(bad_cast: :as_nil)
+  #          #...
+  #        end
   module Model
     extend ActiveSupport::Concern
 

--- a/lib/attr_json/type/model.rb
+++ b/lib/attr_json/type/model.rb
@@ -51,11 +51,13 @@ module AttrJson
         elsif v.respond_to?(:to_h)
           # TODO Maybe we ought not to do this on #to_h?
           model.new_from_serializable(v.to_h)
+        elsif model.attr_json_config.bad_cast == :as_nil
+          # This was originally default behavior, to be like existing ActiveRecord
+          # which kind of silently does this for non-castable basic values. That
+          # ended up being confusing in the basic case, so now we raise by default,
+          # but this is still configurable.
+          nil
         else
-          # Bad input. Originally we were trying to return nil, to be like
-          # existing ActiveRecord which kind of silently does a basic value
-          # with null input. But that ended up making things confusing, let's
-          # just raise.
           raise BadCast.new("Can not cast from #{v.inspect} to #{self.type}")
         end
       end

--- a/spec/record_with_model_spec.rb
+++ b/spec/record_with_model_spec.rb
@@ -333,4 +333,24 @@ RSpec.describe AttrJson::Record do
       end
     end
   end
+
+  describe "bad_cast :as_nil" do
+    let(:model_class) do
+      Class.new do
+        include AttrJson::Model
+
+        attr_json_config(bad_cast: :as_nil)
+
+        attr_json :str, :string
+      end
+    end
+
+    it "casts bad input as nil on access" do
+      instance.model = "not a hash"
+      expect(instance.model).to eq(nil)
+      instance.save!
+      instance.reload
+      expect(instance.model).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
To rescue bad casts to AttrJson::Model as nil, instead of raising. Especially useful when using a model as an AR Serialization coder to cover an entire json column.