### PR TITLE
Test fewer ruby/rails combos on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,6 @@ matrix:
     - rvm: 2.5.3
       gemfile: gemfiles/rails_5_0.gemfile
 
-    - rvm: 2.5.3
-      gemfile: gemfiles/rails_5_1.gemfile
-
-    - rvm: 2.5.3
-      gemfile: gemfiles/rails_5_2.gemfile
-
-    - rvm: 2.5.3
-      gemfile: gemfiles/rails_6_0.gemfile
-
     - rvm: 2.6.5
       gemfile: gemfiles/rails_5_2.gemfile
 


### PR DESCRIPTION
We have too many jobs, it takes too long to run (plus travis has reduced the number of concurrent runners you get).

We don't need to test every ruby/rails version. We'll keep testing the oldest version of ruby we support (2.4) on all versions of Rails we were supporting it on. And we'll make sure to test every rails version. But we don't need to test every rails version on every ruby version, we'll remove a bunch of ruby 2.5 tests, leaving ruby 2.5 only on rails 5.0.