### PR TITLE
Don't accidentally test Rails 6.1 in rails-6-0 group

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -28,7 +28,7 @@ end
 appraise "rails-6-0" do
   gem 'combustion', "~> 1.0"
 
-  gem "rails", ">= 6.0.0.beta1", "< 6.1"
+  gem "rails", ">= 6.0.0", "< 6.1"
   gem "pg", "~> 1.0"
 end
 


### PR DESCRIPTION
Saying >= .beta1 made rubygems/bundler include prereleases, which then allowed 6.1.0.rc1 as < 6.1. We don't need to include beta1 in the spec for the rails 6.0 test anymore. Make sure the 6-0 test tests only latest 6.0.x not 6.1.0.rc1