### PR TITLE
Add weekly scheduled CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ '**' ]
+  # UTC Sundays 0900. note, no notifications will be sent for failed scheduled builds. :(
+  schedule:
+    - cron: '0 9 * * SUN'
+
 
 env:
   POSTGRES_USER: postgres

--- a/.github/workflows/future_rails_ci.yml
+++ b/.github/workflows/future_rails_ci.yml
@@ -19,6 +19,9 @@ name: CI on Future Rails Versions
 on:
   push:
     branches: [ master ]
+  # UTC Sundays 0900. note, no notifications will be sent for failed scheduled builds. :(
+  schedule:
+    - cron: '0 9 * * SUN'
 
 env:
   POSTGRES_USER: postgres


### PR DESCRIPTION
Sadly, nobody will get a notification upon failure. but it will be reflected in the badge, I guess. A work in progress, better than nothing for now.

* https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events

* https://github.community/t/no-email-notification-on-schedule-cron-job-failure/119638