### PR TITLE
only specify ruby minor version to build with latest patch of that minor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,25 +30,25 @@ jobs:
       matrix:
         include:
           - gemfile: rails_5_0
-            ruby: 2.4.5
+            ruby: 2.4
 
           - gemfile: rails_5_0
-            ruby: 2.5.3
+            ruby: 2.5
 
           - gemfile: rails_5_1
-            ruby: 2.4.5
+            ruby: 2.4
 
           - gemfile: rails_5_2
-            ruby: 2.4.5
+            ruby: 2.4
 
           - gemfile: rails_5_2
-            ruby: 2.6.5
+            ruby: 2.6
 
           - gemfile: rails_6_0
-            ruby: 2.6.5
+            ruby: 2.6
 
           - gemfile: rails_6_0
-            ruby: 2.7.0
+            ruby: 2.7
 
     name: ${{ matrix.gemfile }}, ruby ${{ matrix.ruby }}
 

--- a/.github/workflows/future_rails_ci.yml
+++ b/.github/workflows/future_rails_ci.yml
@@ -45,10 +45,10 @@ jobs:
         include:
 
           - gemfile: rails_6_1
-            ruby: 2.7.0
+            ruby: 2.7
 
           - gemfile: rails_edge
-            ruby: 2.7.0
+            ruby: 2.7
 
     name: ${{ matrix.gemfile }}, ruby ${{ matrix.ruby }}
 


### PR DESCRIPTION
Must better. didn't realize the ruby/setup-ruby action supported that.