### PR TITLE
polymorphic single type can be set to nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/jrochkind/attr_json/compare/v1.3.0...HEAD)
 
+### Fixed
+
+* polymorphic single type can be set to nil https://github.com/jrochkind/attr_json/pull/115
+
 ## [1.3.0](https://github.com/jrochkind/attr_json/compare/v1.2.0...v1.3.0)
 
 ### Added

--- a/lib/attr_json/type/polymorphic_model.rb
+++ b/lib/attr_json/type/polymorphic_model.rb
@@ -114,6 +114,8 @@ module AttrJson
       end
 
       def serialize(v)
+        return nil if v.nil?
+
         model_name = v.class.name
         type = type_for_model_name(model_name)
 

--- a/spec/type/polymorphic_type_spec.rb
+++ b/spec/type/polymorphic_type_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe AttrJson::Type::PolymorphicModel do
 
       expect(instance.one_poly).to eq model1.new(str: "str", int: 12)
     end
+
+    it "can set to nil though" do
+      instance.save!
+      expect(instance.one_poly).to be(nil)
+
+      instance.one_poly = model1.new
+      instance.save!
+
+      instance.one_poly = nil
+      instance.save!
+      expect(instance.one_poly).to be(nil)
+    end
+
     it "can set hash with type key" do
       instance.one_poly = { str: "str", int: 12, type: "Model1" }
       instance.save!
@@ -98,9 +111,9 @@ RSpec.describe AttrJson::Type::PolymorphicModel do
       instance.many_poly = [model1.new(str: "str", int: 12), model2.new(str: "str", bool: true)]
       instance.save!
       instance.reload
-
       expect(instance.many_poly).to eq [model1.new(str: "str", int: 12), model2.new(str: "str", bool: true)]
     end
+
     it "can set hashes with type key" do
       instance.many_poly = [{ str: "str", int: 12, type: "Model1" }, { str: "str", bool: true, type: "Model2" }]
       instance.save!


### PR DESCRIPTION
It behaved inconsistently before, where it could have a nil original value, but once you set it to something else, you couldn't set it back without an unexpected raise.

This seems most consistent/backwards-compat, to let you manually set it to nil.

This ends up meaning that a polymorphic array type lets you do , where before it would raise unexpectedly. Not sure what we actually want it to do there, but this is most like a backwards-compat no-change at present, fixing the bug with an unexpected raise. See also #114 questioning in general what is expected behavior with array types and nil