### PR TITLE
Make rails_attribute default true for attr_json 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0]
+
+### Changed
+
+* By default we now create Rails Attribute cover for all attr_json attributes. Ie, `rails_attribute` now defaults to true. https://github.com/jrochkind/attr_json/pull/117
+
 ## [Unreleased](https://github.com/jrochkind/attr_json/compare/v1.3.0...HEAD)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -386,8 +386,6 @@ Use with Rails form builders is supported pretty painlessly. Including with [sim
 
 If you have nested AttrJson::Models you'd like to use in your forms much like Rails associated records: Where you would use Rails `accepts_nested_attributes_for`, instead `include AttrJson::NestedAttributes` and use `attr_json_accepts_nested_attributes_for`. Multiple levels of nesting are supported.
 
-To get simple_form to properly detect your attribute types, define your attributes with `rails_attribute: true`.  You can default rails_attribute to true with `attr_json_config(default_rails_attribute: true)`
-
 For more info, see doc page on [Use with Forms and Form Builders](doc_src/forms.md).
 
 <a name="dirty"></a>

--- a/doc_src/forms.md
+++ b/doc_src/forms.md
@@ -109,19 +109,8 @@ Remember to add `include AttrJson::NestedAttributes` to all your AttrJson::Model
 
 One of the nice parts about [simple_form](https://github.com/plataformatec/simple_form) is how you can just give it `f.input`, and it figures out the right input for you.
 
-AttrJson by default, on an ActiveRecord::Base, doesn't register it's `attr_jsons` in the right way for simple_form to reflect and figure out their types. However, you can ask it to with `rails_attribute: true`.
+AttrJson by default registers  `attr_jsons` as Rails attributes, and provides other appropriate implementations in AttrJson::Model classes, such that simple_form should just work. There are limited CI tests in this project to confirm simple_form stays working.
 
-```ruby
-class SomeRecord < ActiveRecord::Base
-  include AttrJson::Record
-
-  attr_json :my_date, :date, rails_attribute: true
-end
-```
-
-This will use the [ActiveRecord::Base.attribute](http://api.rubyonrails.org/classes/ActiveRecord/Attributes/ClassMethods.html) method to register the attribute and type, and SimpleForm will now be able to automatically look up attribute type just as you expect. (Q: Should we make this default on?)
-
-You don't need to do this in your nested AttrJson::Model classes, SimpleForm will already be able to reflect on their attribute types just fine as is.
 
 ### Arrays of simple attributes
 

--- a/lib/attr_json/config.rb
+++ b/lib/attr_json/config.rb
@@ -16,7 +16,7 @@ module AttrJson
 
     DEFAULTS = {
       default_container_attribute: "json_attributes",
-      default_rails_attribute: false,
+      default_rails_attribute: true,
       unknown_key: :raise
     }
 

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -116,11 +116,13 @@ module AttrJson
       # @option options [Boolean] :validate (true) Create an ActiveRecord::Validations::AssociatedValidator so
       #   validation errors on the attributes post up to self.
       #
-      # @option options [Boolean] :rails_attribute (false) Create an actual ActiveRecord
+      # @option options [Boolean] :rails_attribute (true) Create an actual ActiveRecord
       #    `attribute` for name param. A Rails attribute isn't needed for our functionality,
       #    but registering thusly will let the type be picked up by simple_form and
       #    other tools that may look for it via Rails attribute APIs. Default can be changed
-      #    with `attr_json_config(default_rails_attribute: true)`
+      #    with `attr_json_config(default_rails_attribute: false). Not sure if there's any
+      #    reason to disable this (performance?), and the ability to do so may be removed in
+      #    a future version. `
       def attr_json(name, type, **options)
         options = {
           rails_attribute: self.attr_json_config.default_rails_attribute,

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -172,10 +172,15 @@ module AttrJson
           # for this particular attribute. Yes, we are registering an after_find for each
           # attr_json registered with rails_attribute:true, using the `name` from above under closure. .
           after_find do
-            value = public_send(name)
-            if value && has_attribute?(name.to_sym)
-              write_attribute(name.to_sym, value)
-              self.send(:clear_attribute_changes, [name.to_sym])
+            begin
+              value = public_send(name)
+              if value && has_attribute?(name.to_sym)
+                write_attribute(name.to_sym, value)
+                self.send(:clear_attribute_changes, [name.to_sym])
+              end
+            rescue AttrJson::Type::Model::BadCast, AttrJson::Type::PolymorphicModel::TypeError => e
+              # There was bad data in the DB, we're just going to skip the Rails attribute sync.
+              # Should we log?
             end
           end
         end

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -776,59 +776,55 @@ RSpec.describe AttrJson::Record do
     end
 
     describe "rails_attribute" do
-      it "does not register rails attribute by default" do
-        expect(instance.attributes.keys).not_to include("str")
+      let(:klass) do
+        Class.new(ActiveRecord::Base) do
+          include AttrJson::Record
+
+          self.table_name = "products"
+          attr_json :str, :string, array: true, rails_attribute: true, default: 'foo'
+          attr_json :int, :integer, rails_attribute: true
+        end
       end
-      describe "with rails_attribute: true" do
-        let(:klass) do
-          Class.new(ActiveRecord::Base) do
-            include AttrJson::Record
 
-            self.table_name = "products"
-            attr_json :str, :string, array: true, rails_attribute: true, default: 'foo'
-            attr_json :int, :integer, rails_attribute: true
-          end
-        end
-        it "registers attribute and type" do
-          expect(instance.attributes.keys).to include("str")
-          expect(instance.type_for_attribute("str")).to be_kind_of(AttrJson::Type::Array)
-          expect(instance.type_for_attribute("str").base_type).to be_kind_of(ActiveModel::Type::String)
+      it "registers attribute and type" do
+        expect(instance.attributes.keys).to include("str")
+        expect(instance.type_for_attribute("str")).to be_kind_of(AttrJson::Type::Array)
+        expect(instance.type_for_attribute("str").base_type).to be_kind_of(ActiveModel::Type::String)
 
-        end
+      end
 
-        it "has initial values" do
-          expect(instance.attributes["str"]).to eq ['foo']
-          # this seems to be consistent with ordinary rails attribute use, not marked changed with initial default
-          expect(instance.str_changed?).to be(false)
+      it "has initial values" do
+        expect(instance.attributes["str"]).to eq ['foo']
+        # this seems to be consistent with ordinary rails attribute use, not marked changed with initial default
+        expect(instance.str_changed?).to be(false)
 
-          expect(instance.attributes["int"]).to be_nil
-          expect(instance.str_changed?).to be(false)
-        end
+        expect(instance.attributes["int"]).to be_nil
+        expect(instance.str_changed?).to be(false)
+      end
 
-        it "still has our custom methods on top" do
-          skip "gah, how do we test this"
-        end
+      it "still has our custom methods on top" do
+        skip "gah, how do we test this"
+      end
 
-        it 'syncs Rails attributes and default values after find' do
-          instance.update(str: "our str", int: 100)
-          found_record = klass.find(instance.id)
+      it 'syncs Rails attributes and default values after find' do
+        instance.update(str: "our str", int: 100)
+        found_record = klass.find(instance.id)
 
-          expect(found_record.attributes["str"]).to eq ['our str']
-          expect(found_record.str_changed?).to be(false)
+        expect(found_record.attributes["str"]).to eq ['our str']
+        expect(found_record.str_changed?).to be(false)
 
-          expect(found_record.attributes["int"]).to eq 100
-          expect(found_record.int_changed?).to be(false)
-        end
+        expect(found_record.attributes["int"]).to eq 100
+        expect(found_record.int_changed?).to be(false)
+      end
 
-        it "knows when a change has happened" do
-          expect(instance.str_changed?).to be(false)
+      it "knows when a change has happened" do
+        expect(instance.str_changed?).to be(false)
 
-          instance.str = "new value"
-          expect(instance.str_changed?).to eq(true)
+        instance.str = "new value"
+        expect(instance.str_changed?).to eq(true)
 
-          instance.save!
-          expect(instance.str_changed?).to eq(false)
-        end
+        instance.save!
+        expect(instance.str_changed?).to eq(false)
       end
     end
 


### PR DESCRIPTION
Still considering removing the configuration altogether, just alwasy rails attribute. But for now, we'll do just default true. 

This caused some tests to fail, exposing an existing bug when rails_attribute is true, which we fixed -- consistent behavior with loading from bad data in db. The consistent behavior isn't great, but it's consistent with non-rails-attribute version now.