### PR TITLE
remove coffee-rails from gemfile(s)

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -46,9 +46,4 @@ appraise "rails-edge-6" do
 
   gem "rails", git: "https://github.com/rails/rails.git", branch: "master"
   gem "pg", "~> 1.0"
-
-  # We don't actually use coffeescript at all, we need coffee-rails as an explicit
-  # dependency just for transitory edge weirdness using current sprockets release
-  # with rails 6 edge.
-  gem 'coffee-rails'
 end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -14,6 +14,5 @@ gem "capybara", "~> 3.0"
 gem "webdrivers", "~> 4.0"
 gem "selenium-webdriver"
 gem "byebug"
-gem "coffee-rails"
 
 gemspec path: "../"

--- a/gemfiles/rails_edge_6.gemfile
+++ b/gemfiles/rails_edge_6.gemfile
@@ -14,6 +14,5 @@ gem "capybara", "~> 3.0"
 gem "webdrivers", "~> 4.0"
 gem "selenium-webdriver"
 gem "byebug"
-gem "coffee-rails"
 
 gemspec path: "../"


### PR DESCRIPTION
We never actually used coffee-rails, but it oddly helped get around some bundler issues with past version of edge rails. But currently it is causing some dependency resolution issues with edge rails, let's try without it.