### PR TITLE
remove superfluous railties dependency in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,11 +18,6 @@ gem 'combustion', '~> 1.1'
 # be the way to do it.
 gem 'rails'
 
-# We should not really need to mention railties, it's already a dependency of
-# rails, but seems to be necessary to get around some mystery bug in bundler
-# dependency resolution.
-gem 'railties'
-
 gem "pg"
 gem "rspec-rails", "~> 4.0"
 gem "simple_form", ">= 4.0"

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "combustion", "~> 0.9.0"
 gem "rails", "~> 5.0.0"
-gem "railties"
 gem "pg", "~> 0.18"
 gem "rspec-rails", "~> 4.0"
 gem "simple_form", ">= 4.0"

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "combustion", "~> 0.9.0"
 gem "rails", "~> 5.1.0"
-gem "railties"
 gem "pg", "~> 1.0"
 gem "rspec-rails", "~> 4.0"
 gem "simple_form", ">= 4.0"

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "combustion", "~> 0.9.0"
 gem "rails", "~> 5.2.0"
-gem "railties"
 gem "pg", "~> 1.0"
 gem "rspec-rails", "~> 4.0"
 gem "simple_form", ">= 4.0"

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "combustion", "~> 1.0"
 gem "rails", ">= 6.0.0", "< 6.1"
-gem "railties"
 gem "pg", "~> 1.0"
 gem "rspec-rails", "~> 4.0"
 gem "simple_form", ">= 4.0"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "combustion", "~> 1.0"
 gem "rails", "~> 6.1.0"
-gem "railties"
 gem "pg", "~> 1.0"
 gem "rspec-rails", "~> 4.0"
 gem "simple_form", ">= 4.0"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "combustion", "~> 1.0"
 gem "rails", git: "https://github.com/rails/rails.git", branch: "main"
-gem "railties"
 gem "pg", "~> 1.0"
 gem "rspec-rails", "~> 4.0"
 gem "simple_form", ">= 4.0"


### PR DESCRIPTION
Never made sense, but was working around some previous bundler bug or oddity. But currenlty it is not necessary, and is triggering a DIFFERENT bundler bug or oddity.