### PR TITLE
Straighten up casting vs deserialization of models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/jrochkind/attr_json/compare/v1.3.0...HEAD)
 
+### Changed
+
+* When using store_key feature on an AttrJson::Model, you should not be able to pass in the store_key as a key in initializer or assign_attributes. It was really a bug that this ended up mapped to attribute this way, which could cause a problem in some cases; but calling it out in Changed section because if you were accidentally relying on it, it may appear as a backwards incompat to you. https://github.com/jrochkind/attr_json/pull/125
+
 ### Fixed
 
 * polymorphic single type can be set to nil https://github.com/jrochkind/attr_json/pull/115
 * polymorphic models can be serialized from hash in container attribute. Thanks @machty. https://github.com/jrochkind/attr_json/pull/123
+* fix bug with deserialization of nested attributes that have types that apply different serialization vs cast logic. Thanks @bradleesand. https://github.com/jrochkind/attr_json/pull/125
 
 ## [1.3.0](https://github.com/jrochkind/attr_json/compare/v1.2.0...v1.3.0)
 

--- a/lib/attr_json/type/model.rb
+++ b/lib/attr_json/type/model.rb
@@ -32,10 +32,10 @@ module AttrJson
           # to_hash is actually the 'implicit' conversion, it really is a hash
           # even though it isn't is_a?(Hash), try to_hash first before to_h,
           # the explicit conversion.
-          model.new_from_serializable(v.to_hash)
+          model.new(v.to_hash)
         elsif v.respond_to?(:to_h)
           # TODO Maybe we ought not to do this on #to_h?
-          model.new_from_serializable(v.to_h)
+          model.new(v.to_h)
         elsif model.attr_json_config.bad_cast == :as_nil
           # This was originally default behavior, to be like existing ActiveRecord
           # which kind of silently does this for non-castable basic values. That
@@ -58,7 +58,31 @@ module AttrJson
       end
 
       def deserialize(v)
-        cast(v)
+        if v.nil?
+          # important to stay nil instead of empty object, because they
+          # are different things.
+          v
+        elsif v.kind_of? model
+          v
+        elsif v.respond_to?(:to_hash)
+          # to_hash is actually the 'implicit' conversion, it really is a hash
+          # even though it isn't is_a?(Hash), try to_hash first before to_h,
+          # the explicit conversion.
+          model.new_from_serializable(v.to_hash)
+        elsif v.respond_to?(:to_h)
+          # TODO Maybe we ought not to do this on #to_h? especially here in deserialize?
+          model.new_from_serializable(v.to_h)
+        elsif model.attr_json_config.bad_cast == :as_nil
+          # TODO should we have different config value for bad_deserialize vs bad_cast?
+
+          # This was originally default behavior, to be like existing ActiveRecord
+          # which kind of silently does this for non-castable basic values. That
+          # ended up being confusing in the basic case, so now we raise by default,
+          # but this is still configurable.
+          nil
+        else
+          raise BadCast.new("Can not cast from #{v.inspect} to #{self.type}")
+        end
       end
 
       # these guys are definitely mutable, so we need this.

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe AttrJson::Record do
       # but store_key when serialized
       expect(instance.as_json).to eq("__str_one" => "value")
     end
+
+    it "does not recognize  a store_key in assign_attributes" do
+      expect {
+        instance.assign_attributes("__str_one" => "value")
+      }.to raise_error(ActiveModel::UnknownAttributeError)
+    end
   end
 
   describe "validation" do

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -152,6 +152,39 @@ RSpec.describe AttrJson::Record do
     expect(instance_custom.custom).to eq 'foo'
   end
 
+  describe "type that modifies on serialization" do
+    let(:serialize_transform_str_type) do
+      Class.new(ActiveRecord::Type::Value) do
+        def serialize(value) ; "#{value}_serialized" ; end
+
+        def deserialize(value) ; value.delete_suffix("_serialized") ; end
+
+        def cast(value) ; value ; end
+      end
+    end
+
+    let(:klass) do
+      # closure nonsense
+      _serializing_type = serialize_transform_str_type
+      Class.new(ActiveRecord::Base) do
+        include AttrJson::Record
+
+        self.table_name = "products"
+        attr_json :str, _serializing_type.new
+      end
+    end
+
+    it "properly serializes and deserializes" do
+      instance.str = "foo"
+      instance.save!
+
+      instance.reload
+
+      expect(instance.str).to eq("foo")
+      expect(JSON.parse(instance.json_attributes_before_type_cast)).to eq({"str" => "foo_serialized"})
+    end
+  end
+
   # TODO: Should it LET you redefine instead, and spec for that? Have to pay
   # attention to store keys too if we let people replace attributes.
   it "raises on re-using attribute name" do

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -312,6 +312,12 @@ RSpec.describe AttrJson::Record do
       expect(instance.json_attributes).to eq("_store_key" => "set value")
     end
 
+    it "does not recognize  a store_key in assign_attributes" do
+      expect {
+        instance.assign_attributes("_store_key" => "value")
+      }.to raise_error(ActiveModel::UnknownAttributeError)
+    end
+
     it "raises on conflicting store key" do
       expect {
         Class.new(ActiveRecord::Base) do

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe AttrJson::Record do
       Class.new(ActiveRecord::Type::Value) do
         def serialize(value) ; "#{value}_serialized" ; end
 
-        def deserialize(value) ; value.delete_suffix("_serialized") ; end
+        def deserialize(value) ; value.gsub(/_serialized$/, '') ; end
 
         def cast(value) ; value ; end
       end

--- a/spec/record_with_model_spec.rb
+++ b/spec/record_with_model_spec.rb
@@ -319,6 +319,12 @@ RSpec.describe AttrJson::Record do
       instance_reloaded = klass.find(1)
       expect(instance_reloaded.model.str).to eq("Value")
     end
+
+    it "does not recognize a store_key in assign_attributes" do
+      expect {
+        instance.assign_attributes(model: { "__string__" => "value" })
+      }.to raise_error(ActiveModel::UnknownAttributeError)
+    end
   end
 
   describe "model defaults" do

--- a/spec/record_with_model_spec.rb
+++ b/spec/record_with_model_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe AttrJson::Record do
       Class.new(ActiveRecord::Type::Value) do
         def serialize(value) ; "#{value}_serialized" ; end
 
-        def deserialize(value) ; value.delete_suffix("_serialized") ; end
+        def deserialize(value) ; value.gsub(/_serialized$/, '') ; end
 
         def cast(value) ; value ; end
       end


### PR DESCRIPTION
Casting and deserialization really had to be treated separately, to treat store_keys consistently, and to fix #99 bug with deserialization of nested attributes not happening properly. 

Much thanks to @bradleesand for reporting #99 as a bug, and doing a lot of the legwork to lead to this fix.