### PR TITLE
explicitly include sprockets to get Rails-edge test to pass

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -44,4 +44,9 @@ appraise "rails-edge" do
 
   gem "rails", git: "https://github.com/rails/rails.git", branch: "main"
   gem "pg", "~> 1.0"
+
+  # Current rails 7 master doesn't have sprockets-rails as a dependency.
+  # We don't actually USE sprockets, but we're using "combustion"
+  # gem for rails app setup, which is assumign it. So.
+  gem "sprockets-rails"
 end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -14,5 +14,6 @@ gem "capybara", "~> 3.0"
 gem "webdrivers", "~> 4.0"
 gem "selenium-webdriver"
 gem "byebug"
+gem "sprockets-rails"
 
 gemspec path: "../"


### PR DESCRIPTION
We don't actually use sprockets at all, but the Combustion gem we use to help with testing tries to init it for Rails. To get our tests to pass, we just make Combustion happy in the rails 7-edge environment by adding sprockets-rails as a dependency. https://github.com/pat/combustion/issues/119