### PR TITLE
Fix for new attribute_method_patterns_matching  method name in Rails edge (7.1)

### DIFF
--- a/lib/attr_json/record/dirty.rb
+++ b/lib/attr_json/record/dirty.rb
@@ -270,7 +270,13 @@ module AttrJson
         # find it from currently declared attributes.
         # https://github.com/rails/rails/blob/6aa5cf03ea8232180ffbbae4c130b051f813c670/activemodel/lib/active_model/attribute_methods.rb#L463-L468
         def matched_attribute_method(method_name)
-          matches = self.class.send(:attribute_method_matchers_matching, method_name)
+          if self.class.respond_to?(:attribute_method_patterns_matching, true)
+            # Rails 7.1+
+            matches = self.class.send(:attribute_method_patterns_matching, method_name)
+          else
+            matches = self.class.send(:attribute_method_matchers_matching, method_name)
+          end
+
           matches.detect do |match|
             registry.has_attribute?(match.attr_name)
           end


### PR DESCRIPTION
Our dirty implementation was using ONE Rails private method, and of course that's what broke. Method just seems to have a new name in Rails edge (7.1), easy fix. https://github.com/rails/rails/commit/251445601eb2e00bc15aacf261a85f919ab7f9de#diff-890c7aa1a63d396b1eb9ab738b143d35f276585376d4723cd01cb187fcf76d52L382-R386

We eventually would like to get out of our own custom "dirty" implementation at all, should be able to just use standard Rails after we just make a few tweaks and stop supporting very old Rails.
