### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
           - gemfile: rails_7_0
             ruby: '3.0'
 
+          - gemfile: rails_7_0
+            ruby: 3.1
+
     name: ${{ matrix.gemfile }}, ruby ${{ matrix.ruby }}
 
     steps:


### PR DESCRIPTION
This adds Ruby 3.1 to the CI matrix.  Runs green locally.