### PR TITLE
sets default as array if the attr is an Array

### DIFF
--- a/lib/attr_json/attribute_definition.rb
+++ b/lib/attr_json/attribute_definition.rb
@@ -34,6 +34,8 @@
 
       @default = if options.has_key?(:default)
         options[:default]
+      elsif options[:array] == true
+        []
       else
         NO_DEFAULT_PROVIDED
       end


### PR DESCRIPTION
This PR sets an attribute's default to array if the type is Array and has no other default defined.

This solves the following error when working with `nested_attributes` when using `fields_for` with a `child_index`: 
```ruby
undefined method `stringify_keys' for "Value":String.
```

To reproduce the error use this example https://www.stimulus-components.com/docs/stimulus-rails-nested-form/

This error occurs because an `attr_json` defined as `array:true` is created as `nil` and does not have the `to_ary` method which is used by Rails to create the `child_index`

https://github.com/rails/rails/blob/436207aa2011463e49feb6310fa144bb0a96bf0c/actionview/lib/action_view/helpers/form_helper.rb#L2683

This can also be solved by setting the attr default to `default: []`