### PR TITLE
fix ci on rails edge

### DIFF
--- a/attr_json.gemspec
+++ b/attr_json.gemspec
@@ -51,7 +51,6 @@ attributes use as much of the existing ActiveRecord architecture as we can.}
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", "~> 3.7"
-  spec.add_development_dependency "database_cleaner", "~> 1.5"
   spec.add_development_dependency "yard-activesupport-concern"
   spec.add_development_dependency "appraisal", "~> 2.2"
 

--- a/spec/record_with_model_spec.rb
+++ b/spec/record_with_model_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe AttrJson::Record do
       instance.save!
 
       expect(JSON.parse instance.json_attributes_before_type_cast) .to include("model" => {"__string__" => "Value"})
-      instance_reloaded = klass.find(1)
+      instance_reloaded = klass.find(instance.id)
       expect(instance_reloaded.model.str).to eq("Value")
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -155,7 +155,14 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
-  config.before do
-    DatabaseCleaner.clean_with(:truncation)
+  if Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new("7.1.0.alpha")
+    config.before do
+      DatabaseCleaner.clean_with(:truncation)
+    end
+  else
+    # database_cleaner doesn't currently work with pre-release Rails 7.1.
+    # https://github.com/DatabaseCleaner/database_cleaner/issues/693
+    # But maybe we don't need it anyway, Rails transactional fixtures are fine?
+    config.use_transactional_fixtures = true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,6 @@ Combustion.initialize! :all do
 end
 
 require 'yaml'
-require "database_cleaner"
 require 'byebug'
 require 'attr_json'
 
@@ -155,14 +154,12 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
-  if Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new("7.1.0.alpha")
-    config.before do
-      DatabaseCleaner.clean_with(:truncation)
-    end
-  else
-    # database_cleaner doesn't currently work with pre-release Rails 7.1.
-    # https://github.com/DatabaseCleaner/database_cleaner/issues/693
-    # But maybe we don't need it anyway, Rails transactional fixtures are fine?
-    config.use_transactional_fixtures = true
-  end
+  # This isn't actually just about fixtures, it has Rails clean out our database
+  # after every test, by a strategy of putting each test in a DB transaction that
+  # can be reverted without commit. It's the way we currently make sure the database
+  # is clean for each test, although it could cause a problem if we were doing
+  # threaded stuff. An alternative is database_cleaner, but not currently working
+  # with edge Rails 7.1.
+  # https://github.com/DatabaseCleaner/database_cleaner/issues/693
+  config.use_transactional_fixtures = true
 end


### PR DESCRIPTION
- database_cleaner is currently broken on Rails 7.1 unreleased edge, so stop using it
- Don't assume a record you just inserted has ID 1
