### PR TITLE
Rails attribute is always on

### DIFF
--- a/lib/attr_json/config.rb
+++ b/lib/attr_json/config.rb
@@ -5,7 +5,6 @@ module AttrJson
   class Config
     RECORD_ALLOWED_KEYS = %i{
       default_container_attribute
-      default_rails_attribute
       default_accepts_nested_attributes
     }
 
@@ -16,7 +15,6 @@ module AttrJson
 
     DEFAULTS = {
       default_container_attribute: "json_attributes",
-      default_rails_attribute: true,
       unknown_key: :raise
     }
 

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -24,6 +24,22 @@ module AttrJson
 
       class_attribute :attr_json_registry, instance_accessor: false
       self.attr_json_registry = AttrJson::AttributeDefinition::Registry.new
+
+      # Ensure that rails attributes tracker knows about values we just fetched
+      after_find do
+        self.class.attr_json_registry.attribute_names.each do |attr_name|
+          begin
+            value = public_send(attr_name)
+            if value
+              write_attribute(attr_name, value)
+              clear_attribute_change(attr_name)
+            end
+          rescue AttrJson::Type::Model::BadCast, AttrJson::Type::PolymorphicModel::TypeError => e
+            # There was bad data in the DB, we're just going to skip the Rails attribute sync.
+            # Should we log?
+          end
+        end
+      end
     end
 
     protected
@@ -157,25 +173,6 @@ module AttrJson
         attr_json_definition = attr_json_registry[name]
         attribute_args = attr_json_definition.has_default? ? { default: attr_json_definition.default_argument } : {}
         self.attribute name.to_sym, attr_json_definition.type, **attribute_args
-
-        # Ensure that rails attributes tracker knows about value we just fetched
-        # for this particular attribute. Yes, we are registering an after_find for each
-        # attr_json registered with rails_attribute:true, using the `name` from above under closure. .
-        #
-        # TODO: Consolidate as one after_find
-        after_find do
-          begin
-            value = public_send(name)
-            if value && has_attribute?(name.to_sym)
-              write_attribute(name.to_sym, value)
-              self.send(:clear_attribute_changes, [name.to_sym])
-            end
-          rescue AttrJson::Type::Model::BadCast, AttrJson::Type::PolymorphicModel::TypeError => e
-            # There was bad data in the DB, we're just going to skip the Rails attribute sync.
-            # Should we log?
-          end
-        end
-
 
         _attr_jsons_module.module_eval do
           # For getter and setter, we used to use read_store_attribute/write_store_attribute

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -93,7 +93,8 @@ module AttrJson
       end
 
 
-
+      # Registers an attr_json attribute, and a Rails attribute covering it.
+      #
       # Type can be a symbol that will be looked up in `ActiveModel::Type.lookup`,
       # or an ActiveModel:::Type::Value).
       #
@@ -116,21 +117,13 @@ module AttrJson
       # @option options [Boolean] :validate (true) Create an ActiveRecord::Validations::AssociatedValidator so
       #   validation errors on the attributes post up to self.
       #
-      # @option options [Boolean] :rails_attribute (true) Create an actual ActiveRecord
-      #    `attribute` for name param. A Rails attribute isn't needed for our functionality,
-      #    but registering thusly will let the type be picked up by simple_form and
-      #    other tools that may look for it via Rails attribute APIs. Default can be changed
-      #    with `attr_json_config(default_rails_attribute: false). Not sure if there's any
-      #    reason to disable this (performance?), and the ability to do so may be removed in
-      #    a future version. `
       def attr_json(name, type, **options)
         options = {
-          rails_attribute: self.attr_json_config.default_rails_attribute,
           validate: true,
           container_attribute: self.attr_json_config.default_container_attribute,
           accepts_nested_attributes: self.attr_json_config.default_accepts_nested_attributes
         }.merge!(options)
-        options.assert_valid_keys(AttributeDefinition::VALID_OPTIONS + [:validate, :rails_attribute, :accepts_nested_attributes])
+        options.assert_valid_keys(AttributeDefinition::VALID_OPTIONS + [:validate, :accepts_nested_attributes])
         container_attribute = options[:container_attribute]
 
         # TODO arg check container_attribute make sure it exists. Hard cause
@@ -152,7 +145,7 @@ module AttrJson
         end
 
         self.attr_json_registry = attr_json_registry.with(
-          AttributeDefinition.new(name.to_sym, type, options.except(:rails_attribute, :validate, :accepts_nested_attributes))
+          AttributeDefinition.new(name.to_sym, type, options.except(:validate, :accepts_nested_attributes))
         )
 
         # By default, automatically validate nested models
@@ -160,30 +153,29 @@ module AttrJson
           self.validates_with ActiveRecord::Validations::AssociatedValidator, attributes: [name.to_sym]
         end
 
-        # We don't actually use this for anything, we provide our own covers. But registering
-        # it with usual system will let simple_form and maybe others find it.
-        if options[:rails_attribute]
-          attr_json_definition = attr_json_registry[name]
+        # Register as a Rails attribute
+        attr_json_definition = attr_json_registry[name]
+        attribute_args = attr_json_definition.has_default? ? { default: attr_json_definition.default_argument } : {}
+        self.attribute name.to_sym, attr_json_definition.type, **attribute_args
 
-          attribute_args = attr_json_definition.has_default? ? { default: attr_json_definition.default_argument } : {}
-          self.attribute name.to_sym, attr_json_definition.type, **attribute_args
-
-          # Ensure that rails attributes tracker knows about value we just fetched
-          # for this particular attribute. Yes, we are registering an after_find for each
-          # attr_json registered with rails_attribute:true, using the `name` from above under closure. .
-          after_find do
-            begin
-              value = public_send(name)
-              if value && has_attribute?(name.to_sym)
-                write_attribute(name.to_sym, value)
-                self.send(:clear_attribute_changes, [name.to_sym])
-              end
-            rescue AttrJson::Type::Model::BadCast, AttrJson::Type::PolymorphicModel::TypeError => e
-              # There was bad data in the DB, we're just going to skip the Rails attribute sync.
-              # Should we log?
+        # Ensure that rails attributes tracker knows about value we just fetched
+        # for this particular attribute. Yes, we are registering an after_find for each
+        # attr_json registered with rails_attribute:true, using the `name` from above under closure. .
+        #
+        # TODO: Consolidate as one after_find
+        after_find do
+          begin
+            value = public_send(name)
+            if value && has_attribute?(name.to_sym)
+              write_attribute(name.to_sym, value)
+              self.send(:clear_attribute_changes, [name.to_sym])
             end
+          rescue AttrJson::Type::Model::BadCast, AttrJson::Type::PolymorphicModel::TypeError => e
+            # There was bad data in the DB, we're just going to skip the Rails attribute sync.
+            # Should we log?
           end
         end
+
 
         _attr_jsons_module.module_eval do
           # For getter and setter, we used to use read_store_attribute/write_store_attribute

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -820,8 +820,8 @@ RSpec.describe AttrJson::Record do
           include AttrJson::Record
 
           self.table_name = "products"
-          attr_json :str, :string, array: true, rails_attribute: true, default: 'foo'
-          attr_json :int, :integer, rails_attribute: true
+          attr_json :str, :string, array: true, default: 'foo'
+          attr_json :int, :integer
         end
       end
 


### PR DESCRIPTION
- Remove rails_attribute option, we now always create rails attributes on Records
- Consolidate single after_find callback
