### PR TITLE
Fix bug involving conflict between AttrJson::Model NestedAttributes and defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/jrochkind/attr_json/compare/v1.4.0...HEAD)
 
 
+## [1.4.1](https://github.com/jrochkind/attr_json/compare/v1.4.0...v1.4.1)
 
+### Fixed
+
+* Fixed an obscure bug involving a conflict between attribute defaults and accepts_nested_attributes, in which defaults could overwrite assigned attributes. The `.fill_in_defaults` class method, which was never intended as public API and was commented accordingly, is gone. https://github.com/jrochkind/attr_json/pull/160
 
 ## [1.4.0](https://github.com/jrochkind/attr_json/compare/v1.3.0...v1.4.0)
 

--- a/spec/nested_attributes/nested_attributes_spec.rb
+++ b/spec/nested_attributes/nested_attributes_spec.rb
@@ -244,6 +244,28 @@ RSpec.describe AttrJson::NestedAttributes do
 
       expect(instance.many_models).to eq [model_class.new(str: "Someone", int: "101"), model_class.new(str: "Someone Else", int: "102")]
     end
+
+    describe "nested, with an inner default" do
+      let(:klass) do
+        Class.new do
+          include AttrJson::Model
+          include AttrJson::NestedAttributes
+
+          attr_json :array_of_strings, :string, array: true, default: -> { [] }
+
+          attr_json_accepts_nested_attributes_for :array_of_strings
+        end
+      end
+
+      it "can initialize with _attributes key" do
+        # this is proof of a bug fix. While you maybe wouldn't send
+        # an _attributes keys in initializer like this, you ought to be able to,
+        # and it turns out it needs to work for actual use cases involving nested attributes
+        # and AttrJson::Model
+        obj = klass.new(array_of_strings_attributes: ["a", "b"])
+        expect(obj.array_of_strings).to eq ["a", "b"]
+      end
+    end
   end
 
   describe "multiparameter attributes" do


### PR DESCRIPTION
Ran into this bug in a real world case involving setting array default to empty array. It was very confusing and complicated, I found it too hard to reproduce the actual case in a spec, this simple spec was the best I could do for failing before the change passing after.

Only apply defaults after initialiation, with args passed in initialization, only if defaults are still needed. Previously, defaults were sometimes accidentally over-writing values set with `*_attributes` keys, in real world use cases.

`.fill_in_defaults` class method is removed -- it was never meant as public API anyhow. 

This is a better way of doing defaults anyway... not sure what the comment saying that method couldn't be private was about, or why it was on class instead of instance. I think those were leftover from previous implementations, currently this is simpler anyhow.


