### PR TITLE
Array attributes should by default have an empty array default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Drop Rails earlier than 6.0 and ruby earlier than 2.6. https://github.com/jrochkind/attr_json/pull/155
 
+* Array types now default to an empty array. If you'd like to turn that off, you can use the somewhat odd `default: AttrJson::AttributeDefinition::NO_DEFAULT_PROVIDED` on attribute definiton. Thanks @g13ydson for suggestion. https://github.com/jrochkind/attr_json/pull/161
+
 ## [1.4.1](https://github.com/jrochkind/attr_json/compare/v1.4.0...v1.4.1)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ class MyModel < ActiveRecord::Base
    attr_json :my_integer, :integer
    attr_json :my_datetime, :datetime
 
-   # You can have an _array_ of those things too.
+   # You can have an _array_ of those things too. It will ordinarily default to empty array.
    attr_json :int_array, :integer, array: true
 
    #and/or defaults

--- a/lib/attr_json/attribute_definition.rb
+++ b/lib/attr_json/attribute_definition.rb
@@ -34,6 +34,8 @@
 
       @default = if options.has_key?(:default)
         options[:default]
+      elsif options[:array] == true
+        -> { [] }
       else
         NO_DEFAULT_PROVIDED
       end

--- a/lib/attr_json/model.rb
+++ b/lib/attr_json/model.rb
@@ -143,6 +143,8 @@ module AttrJson
       # @param type [ActiveModel::Type::Value] An instance of an ActiveModel::Type::Value (or subclass)
       #
       # @option options [Boolean] :array (false) Make this attribute an array of given type.
+      #    Array types default to an empty array. If you want to turn that off, you can add
+      #    `default: AttrJson::AttributeDefinition::NO_DEFAULT_PROVIDED`
       #
       # @option options [Object] :default (nil) Default value, if a Proc object it will be #call'd
       #   for default.

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -119,6 +119,8 @@ module AttrJson
       # @param type [ActiveModel::Type::Value] An instance of an ActiveModel::Type::Value (or subclass)
       #
       # @option options [Boolean] :array (false) Make this attribute an array of given type.
+      #    Array types default to an empty array. If you want to turn that off, you can add
+      #    `default: AttrJson::AttributeDefinition::NO_DEFAULT_PROVIDED`
       #
       # @option options [Object] :default (nil) Default value, if a Proc object it will be #call'd
       #   for default.

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -37,6 +37,36 @@ RSpec.describe AttrJson::Record do
     end
   end
 
+  describe "array types" do
+    let(:klass) do
+      Class.new do
+        include AttrJson::Model
+
+        attr_json :str_array, :string, array: true
+      end
+    end
+
+    it "defaults to empty array" do
+      expect(instance.str_array).to eq []
+    end
+
+    describe "with explicit no default" do
+      let(:klass) do
+        Class.new do
+          include AttrJson::Model
+
+          # Very hacky, but a way to override empty array default
+          attr_json :str_array, :string, array: true, default: AttrJson::AttributeDefinition::NO_DEFAULT_PROVIDED
+        end
+      end
+
+      it "has no default" do
+        expect(instance.as_json).not_to have_key("str_array")
+        expect(instance.str_array).to eq nil
+      end
+    end
+  end
+
   describe "validation" do
     let(:klass) do
       Class.new do

--- a/spec/record_with_model_spec.rb
+++ b/spec/record_with_model_spec.rb
@@ -255,8 +255,8 @@ RSpec.describe AttrJson::Record do
         serialized = JSON.parse(instance.json_attributes_before_type_cast)
 
         expect(serialized["models"]).to eq([
-          {"str"=>"string value", "int"=>12, "int_with_default"=>5},
-          {"str"=>"string value", "int"=>12, "int_with_default"=>5}
+          {"str"=>"string value", "int"=>12, "int_with_default"=>5, "int_array" => []},
+          {"str"=>"string value", "int"=>12, "int_with_default"=>5, "int_array" => []}
         ])
       end
     end
@@ -274,7 +274,7 @@ RSpec.describe AttrJson::Record do
         serialized = JSON.parse(instance.json_attributes_before_type_cast)
 
         expect(serialized["models"]).to eq([
-          {"str"=>"string value", "int"=>12, "int_with_default"=>5}
+          {"str"=>"string value", "int"=>12, "int_with_default"=>5, "int_array" => [] }
         ])
       end
     end


### PR DESCRIPTION
Array types now default to an empty array. If you'd like to turn that off, you can use the somewhat odd `default: AttrJson::AttributeDefinition::NO_DEFAULT_PROVIDED` on attribute definiton. Thanks @g13ydson for suggestion in #149 
