### PR TITLE
Timezone aware attribute conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Array types now default to an empty array. If you'd like to turn that off, you can use the somewhat odd `default: AttrJson::AttributeDefinition::NO_DEFAULT_PROVIDED` on attribute definiton. Thanks @g13ydson for suggestion. https://github.com/jrochkind/attr_json/pull/161
 
+### Added
+
+* ActiveRecord-style "timezone-aware attribute" conversion now works properly, in both AttrJson::Record and (similarly) AttrJson::Model. https://github.com/jrochkind/attr_json/pull/164
+
 ### Fixed
 
 * the `AttrJson::Type::Array` type used for our array types was not properly tracking in-place mutation changes. Now it is https://github.com/jrochkind/attr_json/pull/163

--- a/lib/attr_json/config.rb
+++ b/lib/attr_json/config.rb
@@ -11,6 +11,7 @@ module AttrJson
     MODEL_ALLOWED_KEYS = %i{
       unknown_key
       bad_cast
+      time_zone_aware_attributes
     }
 
     DEFAULTS = {

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -308,8 +308,22 @@ RSpec.describe AttrJson::Record do
       expect(deserialized.json_datetime.class).to eq(ActiveSupport::TimeWithZone)
       expect(deserialized.json_datetime.time_zone).to eq ActiveSupport::TimeZone.new(time_zone)
     end
+
+    describe "disabled with attr_json config" do
+      let(:klass) do
+        Class.new do
+          include AttrJson::Model
+
+          attr_json_config(time_zone_aware_attributes: false)
+
+          attr_json :json_datetime, :datetime
+        end
+      end
+
+      it "does not convert on create" do
+        expect(instance.json_datetime.class).to eq(Time)
+        expect(instance.json_datetime.zone).to eq(time_value.zone)
+      end
+    end
   end
-
-
-
 end


### PR DESCRIPTION
Timezone aware attributes, like standard ActiveRecord!  Ref #16

* For attributes in AttrJson::Record (directly on ActiveRecord) -- the things we did to sync objects between ActiveRecord attributes and our canonical hash in #163 -- made this just work! We were able to activate the existing pending tests, and they just passed! (modulo some wrong expectations in one test)
  *  What if this breaks in the future, or we find edge cases that break it?  We could add our own implementation in AttrJson::Record too -- the built in ActiveRecord stuff [should avoid double-wrapping in the conversion type](https://github.com/rails/rails/blob/v7.0.4/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb#L10). But we took the win. 

* For AttrJson::Model model objects -- we had to provide an implementation, the Rails stuff is _only_ in ActiveRecord. 
  * We tried to re-use as much from ActiveRecord as possible, to keep things consistent. ActiveRecord uses a "wrapper" `Type` object, [ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter](https://github.com/rails/rails/blob/v7.0.4/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb), and we re-use it!
  * ActiveRecord technically has model-class-specific configuration to turn this on and off, although I doubt many use it. By default, we here in AttrJson::Model use the configuration on `ActiveRecord::Base`. 
  * But you can opt into something else with `attr_json_config(time_zone_aware_attributes: true)`, or `false`, or an array of custom `time_zone_aware_types`. I don't expect most people will need this... but I added it anyway?

This somewhat complicates the implementation of AttrJson::Model... but I think it just is what it is. I'm going to sleep on it for the break, but then probably merge. 