### PR TITLE
Test edge rails (current 7.1 pre-release) with ruby 3.1

### DIFF
--- a/.github/workflows/future_rails_ci.yml
+++ b/.github/workflows/future_rails_ci.yml
@@ -45,7 +45,7 @@ jobs:
         include:
 
           - gemfile: rails_edge
-            ruby: '3.0'
+            ruby: '3.1'
 
     name: ${{ matrix.gemfile }}, ruby ${{ matrix.ruby }}
 


### PR DESCRIPTION
Rails 7.1 now requires a version of rubygems later than what comes with ruby 3.0, we should just be testing future Rails 7.1 with ruby 3.1 anyway probably.

But this change is one way to avoid our error in CI:

> rails-7.1.0.alpha requires rubygems version >= 3.3.13, which is incompatible
with the current version, 3.2.33
