### PR TITLE
Strip nils from Model serialization for more compact representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * time or datetime types used to truncate all fractional seconds to 0. Now they properly allow precision of `ActiveSupport::JSON::Encoding.time_precision` (normally three decimal places, ie milliseconds). And by default the Type::Value's are set to proper precision for cast too. https://github.com/jrochkind/attr_json/pull/173
 
+* AttrJson::Models are serialized without nil values in the hash, for more compact representations. This is only done for attributes without defaults. This behavior can be disabled/altered when specifying the type. https://github.com/jrochkind/attr_json/pull/175
+
 ### Added
 
 * ActiveRecord-style "timezone-aware attribute" conversion now works properly, in both AttrJson::Record and (similarly) AttrJson::Model. https://github.com/jrochkind/attr_json/pull/164

--- a/lib/attr_json/model.rb
+++ b/lib/attr_json/model.rb
@@ -80,6 +80,15 @@ module AttrJson
   #   serialize :some_json_column, ValueModel.to_serialize_coder
   # end
   #
+  # # Strip nils
+  #
+  # When embedded in an `attr_json` attribute, models are normally serialized with `nil` values
+  # stripped from hash where possible, for a more compact representation.
+  # This can be set differently in the type.
+  #
+  #     attr_json :lang_and_value, LangAndValue.to_type(strip_nils: false)
+  #
+  # See #serializable_hash docs for possible values.
   module Model
     extend ActiveSupport::Concern
 
@@ -144,8 +153,12 @@ module AttrJson
 
       # @returns ActiveModel::Type suitable for including this model in
       # an AttrJson::Record or ::Model attribute
-      def to_type
-        @type ||= AttrJson::Type::Model.new(self)
+      #
+      # @param strip_nils [Boolean,Symbol] [true,false,:safely] as a type,
+      #   should we strip nils when serializing? By default this type strips
+      #   nils in :safely mode. See AttrJson::Model#serializable_hash
+      def to_type(strip_nils: :safely)
+        @type ||= AttrJson::Type::Model.new(self, strip_nils: strip_nils)
       end
 
       def to_serialization_coder

--- a/lib/attr_json/model.rb
+++ b/lib/attr_json/model.rb
@@ -20,7 +20,7 @@ module AttrJson
   # Meant for use as an attribute of a AttrJson::Record. Can be nested,
   # AttrJson::Models can have attributes that are other AttrJson::Models.
   #
-  # @note Includes ActiveModel::Model whether you like it or not. TODO, should it?
+  # @note Includes ActiveModel::Model whether you like it or not.
   #
   # You can control what happens if you set an unknown key (one that you didn't
   # register with `attr_json`) with the config attribute `attr_json_config(unknown_key:)`.
@@ -121,7 +121,7 @@ module AttrJson
       # The inverse of model#serializable_hash -- re-hydrates a serialized hash to a model.
       #
       # Similar to `.new`, but translates things that need to be translated in deserialization,
-      # like store_keys, and properly calling deserialize on the underlying types.
+      # like store_keys, and properly calling deserialize (rather than cast) on the underlying types.
       #
       # @example Model.new_from_serializable(hash)
       def new_from_serializable(attributes = {})
@@ -142,6 +142,8 @@ module AttrJson
         self.new(attributes)
       end
 
+      # @returns ActiveModel::Type suitable for including this model in
+      # an AttrJson::Record or ::Model attribute
       def to_type
         @type ||= AttrJson::Type::Model.new(self)
       end
@@ -287,31 +289,65 @@ module AttrJson
       self.class.attr_json_registry.has_attribute?(str)
     end
 
-    # Override from ActiveModel::Serialization to #serialize
-    # by type to make sure any values set directly on hash still
+    # Override from ActiveModel::Serialization to:
+    #
+    # * handle store_key settings
+    #
+    # * #serialize by type to make sure any values set directly on hash still
     # get properly type-serialized.
-    def serializable_hash(*options)
-      super.collect do |key, value|
+    #
+    # * custom logic for keeping nil values out of serialization to be more compact
+    #
+    # @param strip_nils [:symbol, Boolean] (default false) Should we keep keys with
+    #   `nil` values out of the serialization entirely? You might want to to keep
+    #   your in-database serialization compact. By default this method does not -- but
+    #   by default AttrJson::Type::Model sends `:safely` when serializing.
+    #     * false => do not strip nils
+    #     * :safely => strip nils only when there is no default value for the attribute,
+    #       so `nil` can still override the default value
+    #     * true => strip nils even if there is a default value -- in AttrJson
+    #       context, this means the default will be reapplied over nil on
+    #       every de-serialization!
+    def serializable_hash(strip_nils:false, **options)
+      unless [true, false, :safely].include?(strip_nils)
+        raise ArgumentError, ":strip_nils must be true, false, or :safely"
+      end
+
+      super(options).collect do |key, value|
         if attribute_def = self.class.attr_json_registry[key.to_sym]
           key = attribute_def.store_key
+
           if value.kind_of?(Time) || value.kind_of?(DateTime)
             value = value.utc.change(usec: 0)
           end
 
           value = attribute_def.serialize(value)
         end
-        # Do we need unknown key handling here? Apparently not?
-        [key, value]
-      end.to_h
+
+        # strip_nils handling
+        if value.nil? && (
+           (strip_nils == :safely && !attribute_def&.has_default?) ||
+            strip_nils == true )
+        then
+          # do not include in serializable_hash
+          nil
+        else
+          [key, value]
+        end
+      end.compact.to_h
     end
 
     # ActiveRecord JSON serialization will insist on calling
     # this, instead of the specified type's #serialize, at least in some cases.
     # So it's important we define it -- the default #as_json added by ActiveSupport
     # will serialize all instance variables, which is not what we want.
-    def as_json(*options)
-      serializable_hash(*options)
+    #
+    # @param strip_nils [:symbol, Boolean] (default false) [true, false, :safely],
+    #   see #serializable_hash
+    def as_json(**kwargs)
+      serializable_hash(**kwargs)
     end
+
 
     # We deep_dup on #to_h, you want attributes unduped, ask for #attributes.
     def to_h

--- a/lib/attr_json/type/model.rb
+++ b/lib/attr_json/type/model.rb
@@ -8,13 +8,22 @@ module AttrJson
     # but normally that's only done in AttrJson::Model.to_type, there isn't
     # an anticipated need to create from any other place.
     #
+    #
     class Model < ::ActiveModel::Type::Value
       class BadCast < ArgumentError ; end
 
-      attr_accessor :model
-      def initialize(model)
+      attr_accessor :model, :strip_nils
+
+      # @param model [AttrJson::Model] the model _class_ object
+      # @param strip_nils [Symbol,Boolean] [true, false, or :safely]
+      #  (default :safely), As a type, should we strip nils when serialiing?
+      #  This value passed to AttrJson::Model#serialized_hash(strip_nils).
+      #  by default it's :safely, we strip nils when it can be done safely
+      #  to preserve default overrides.
+      def initialize(model, strip_nils: :safely)
         #TODO type check, it really better be a AttrJson::Model. maybe?
         @model = model
+        @strip_nils = strip_nils
       end
 
       def type
@@ -51,9 +60,9 @@ module AttrJson
         if v.nil?
           nil
         elsif v.kind_of?(model)
-          v.serializable_hash
+          v.serializable_hash(strip_nils: strip_nils)
         else
-          (cast_v = cast(v)) && cast_v.serializable_hash
+          (cast_v = cast(v)) && cast_v.serializable_hash(strip_nils: strip_nils)
         end
       end
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -326,4 +326,37 @@ RSpec.describe AttrJson::Record do
       end
     end
   end
+
+  describe "serialization" do
+    let(:klass) do
+      Class.new do
+        include AttrJson::Model
+
+        attr_json :str, :string
+        attr_json :str_with_default, :string, default: "foo"
+      end
+    end
+
+    it "includes all nils by default" do
+     expect(klass.new(str: nil, str_with_default: nil).serializable_hash).to eq(
+        { "str_with_default" => nil, "str" =>  nil }
+      )
+    end
+
+    describe "strip_nils: safely" do
+      it "omits keys for nil values, unless they have defaults configured" do
+        expect(klass.new(str: nil, str_with_default: nil).serializable_hash(strip_nils: :safely)).to eq(
+          { "str_with_default" => nil}
+        )
+      end
+    end
+
+    describe "strip_nils: true" do
+      it "strips all nils" do
+       expect(klass.new(str: nil, str_with_default: nil).serializable_hash(strip_nils: true)).to eq(
+          { }
+        )
+      end
+    end
+  end
 end

--- a/spec/nested_attributes/nested_attributes_spec.rb
+++ b/spec/nested_attributes/nested_attributes_spec.rb
@@ -160,7 +160,8 @@ RSpec.describe AttrJson::NestedAttributes do
         expect(instance.many_models).to be_present
         expect(instance.many_models.all? {|a| a.kind_of? model_class})
 
-        expect(instance.many_models).to eq [model_class.new(str: "foo", int: nil)]
+        # int casts to nil, then is stripped
+        expect(instance.many_models).to eq [model_class.new(str: "foo")]
       end
     end
 

--- a/spec/record_with_model_spec.rb
+++ b/spec/record_with_model_spec.rb
@@ -372,6 +372,16 @@ RSpec.describe AttrJson::Record do
   end
 
   describe "model defaults" do
+    it "can be overridden to nil, and stick through serialization" do
+      instance.model = { int_with_default: nil }
+      expect(instance.model.int_with_default).to be_nil
+
+      instance.save!
+      instance.reload
+
+      expect(instance.model.int_with_default).to be_nil
+    end
+
     describe "empty hash" do
       let(:klass) do
         # really hard to get the class def closure to capture the rspec
@@ -391,6 +401,7 @@ RSpec.describe AttrJson::Record do
         expect(instance.model.int_with_default).to be_present
       end
     end
+
     describe "constructor lambda" do
       let(:klass) do
         # really hard to get the class def closure to capture the rspec
@@ -430,6 +441,29 @@ RSpec.describe AttrJson::Record do
       instance.save!
       instance.reload
       expect(instance.model).to eq(nil)
+    end
+  end
+
+  describe "nil values in model" do
+    let(:model_class) do
+      Class.new do
+        include AttrJson::Model
+
+        attr_json :str, :string
+        attr_json :str_with_default, :string, default: "default"
+      end
+    end
+
+    it "are stripped safely by default" do
+      instance.model = { str: nil, str_with_default: nil }
+      instance.save!
+
+      # nil with default is left in safely, nil without default is stripped
+      expect(
+        JSON.parse(instance.json_attributes_before_type_cast)
+      ).to eq(
+        {"model"=>{"str_with_default"=>nil}}
+      )
     end
   end
 end


### PR DESCRIPTION
We want to mostly keep unnecessary nils out of serializations, to keep them more compact. This will become even more relevant if we move to a full `AttrJson::Attributes` implementation -- or something semantically like it -- where by default *all* attributes are included in serialized hash, even if never set.  We don't really need to serialize them all in postgres. 

* `AttrJson::Model#serializable_hash` (and #as_json) now have a new optional `strip_attributes` keyword argument. Default is `false`, do same as traditional.  `true` leaves keys for all nil values out of the hash -- but that causes problems for trying to save a `nil` written on top of another default. So `:safely` strips nils only for attributes without defaults. 

* The `AttrJson::Model::Type` type class will by default serialize with `:safely` -- stripping unnecessary nils. But you can change this with a paramter, that you can also pass to `AttrJson::Model#to_type`. So for instance, when embedding a model somewhere:
      
         attr_json :some_model, SomeModel.to_type(strip_nils: false)
         attr_json :some_more_model, SomeModel.to_type(strip_nils: true)

  If set to to `strip_nils: true`, the effect is when *deserializing* a model with an attribute with a default, the default ends up re-applied on top of previously nil values. Kind of making the default applied not just on original creation, but on every de-serialization too. 