### PR TITLE
Default nested model validation should allow nils in arrays of models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ While it has some backwards incompat changes, this is expected not to be a chall
 
 * the `AttrJson::Type::Array` type used for our array types was not properly tracking in-place mutation changes. Now it is https://github.com/jrochkind/attr_json/pull/163
 
+* Default nested model validation should allow nils in arrays of models. https://github.com/jrochkind/attr_json/pull/177
+
 
 
 ## [1.5.0](https://github.com/jrochkind/attr_json/compare/v1.4.1...v1.5.0)

--- a/spec/record_with_model_spec.rb
+++ b/spec/record_with_model_spec.rb
@@ -332,6 +332,17 @@ RSpec.describe AttrJson::Record do
         ])
       end
     end
+
+    describe "nil items" do
+      it "pass through and remain nil" do
+        instance.models = [model_class.new, nil, model_class.new]
+        instance.save!
+        instance.reload
+
+        expect(instance.models.count).to eq 3
+        expect(instance.models.collect(&:class)).to eq [model_class, NilClass, model_class]
+      end
+    end
   end
 
   describe "model with store_keys" do


### PR DESCRIPTION
closes #114
