### PR TITLE
More care with appropriate types with attr_json_accepts_nested_attributes_for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ While it has some backwards incompat changes, this is expected not to be a chall
 
 * The `rails_attribute` param to `attr_json` or `attr_json_config` no longer exists. We now always create rails attributes for AttrJson::Record attributes. https://github.com/jrochkind/attr_json/pull/117 and https://github.com/jrochkind/attr_json/pull/158
 
+*  AttrJson::Type::Array#base_type_primitive? is gone. Doubt anyone used it externally. https://github.com/jrochkind/attr_json/pull/178
+
 ### Changed
 
 * We now create Rails Attribute cover for all attr_json attributes, and we do a better job of keeping the Rails attribute values sync'd with attr_json values.   https://github.com/jrochkind/attr_json/pull/117, https://github.com/jrochkind/attr_json/pull/158, and https://github.com/jrochkind/attr_json/pull/163
@@ -29,6 +31,8 @@ While it has some backwards incompat changes, this is expected not to be a chall
 * time or datetime types used to truncate all fractional seconds to 0. Now they properly allow precision of `ActiveSupport::JSON::Encoding.time_precision` (normally three decimal places, ie milliseconds). And by default the Type::Value's are set to proper precision for cast too. https://github.com/jrochkind/attr_json/pull/173
 
 * AttrJson::Models are serialized without nil values in the hash, for more compact representations. This is only done for attributes without defaults. This behavior can be disabled/altered when specifying the type. https://github.com/jrochkind/attr_json/pull/175
+
+* config default_accepts_nested_attributes will only apply nested attributes to suitable attribute types (array or nested model), the default won't apply to inapplicable types. https://github.com/jrochkind/attr_json/pull/178
 
 ### Added
 

--- a/lib/attr_json/attribute_definition.rb
+++ b/lib/attr_json/attribute_definition.rb
@@ -94,8 +94,16 @@
       type.is_a? AttrJson::Type::Array
     end
 
-    def single_model_type?
-      type.is_a?(AttrJson::Type::Model) || type.is_a?(AttrJson::Type::PolymorphicModel)
+    # Used for figuring out appropriate behavior for nested attribute implementation among
+    # other places. true if type is a nested model, either straight or polymorphic
+    def single_model_type?(arg_type=self.type)
+      arg_type.is_a?(AttrJson::Type::Model) || arg_type.is_a?(AttrJson::Type::PolymorphicModel)
+    end
+
+    # Used for figuring out appropriate behavior in nested attribute implementation among
+    # other places. true if type is an array of things that are not nested models.
+    def array_of_primitive_type?
+      array_type? && !single_model_type?(type.base_type)
     end
 
     # Can look up a symbol to a type, or leave a type alone, or raise if it's neither.

--- a/lib/attr_json/attribute_definition.rb
+++ b/lib/attr_json/attribute_definition.rb
@@ -94,6 +94,10 @@
       type.is_a? AttrJson::Type::Array
     end
 
+    def single_model_type?
+      type.is_a?(AttrJson::Type::Model) || type.is_a?(AttrJson::Type::PolymorphicModel)
+    end
+
     # Can look up a symbol to a type, or leave a type alone, or raise if it's neither.
     # Extracted into a method, so it can be called from AttrJson::Model#attr_json, for
     # some timezone aware shenanigans.

--- a/lib/attr_json/nested_attributes.rb
+++ b/lib/attr_json/nested_attributes.rb
@@ -65,6 +65,10 @@ module AttrJson
             raise ArgumentError, "No attr_json found for name '#{attr_name}'. Has it been defined yet?"
           end
 
+          unless attr_def.array_type? || attr_def.single_model_type?
+            raise TypeError, "attr_json_accepts_nested_attributes_for is only for array or nested model types; `#{attr_name}` is type #{attr_def.type.type.inspect}"
+          end
+
           # We're sharing AR class attr in an AR, or using our own in a Model.
           nested_attributes_options = self.nested_attributes_options.dup
           nested_attributes_options[attr_name.to_sym] = options

--- a/lib/attr_json/nested_attributes.rb
+++ b/lib/attr_json/nested_attributes.rb
@@ -80,7 +80,7 @@ module AttrJson
           end
 
           # No build method for our wacky array of primitive type.
-          if options[:define_build_method] && !(attr_def.array_type? && attr_def.type.base_type_primitive?)
+          if options[:define_build_method] && !attr_def.array_of_primitive_type?
             _attr_jsons_module.module_eval do
               build_method_name = "build_#{attr_name.to_s.singularize}"
               if method_defined?(build_method_name)

--- a/lib/attr_json/nested_attributes/writer.rb
+++ b/lib/attr_json/nested_attributes/writer.rb
@@ -16,7 +16,7 @@ module AttrJson
 
       def assign_nested_attributes(attributes)
         if attr_def.array_type?
-          if attr_def.type.base_type_primitive?
+          if attr_def.array_of_primitive_type?
             assign_nested_attributes_for_primitive_array(attributes)
           else
             assign_nested_attributes_for_model_array(attributes)

--- a/lib/attr_json/nested_attributes/writer.rb
+++ b/lib/attr_json/nested_attributes/writer.rb
@@ -15,12 +15,10 @@ module AttrJson
       delegate :nested_attributes_options, to: :model
 
       def assign_nested_attributes(attributes)
-        if attr_def.array_type?
-          if attr_def.array_of_primitive_type?
-            assign_nested_attributes_for_primitive_array(attributes)
-          else
-            assign_nested_attributes_for_model_array(attributes)
-          end
+        if attr_def.array_of_primitive_type?
+          assign_nested_attributes_for_primitive_array(attributes)
+        elsif attr_def.array_type?
+          assign_nested_attributes_for_model_array(attributes)
         else
           assign_nested_attributes_for_single_model(attributes)
         end

--- a/lib/attr_json/type/array.rb
+++ b/lib/attr_json/type/array.rb
@@ -45,12 +45,6 @@ module AttrJson
         ]
       end
 
-      # Hacky, hard-coded classes, but used in our weird primitive implementation in NestedAttributes,
-      # better than putting the conditionals there
-      def base_type_primitive?
-        !(base_type.is_a?(AttrJson::Type::Model) || base_type.is_a?(AttrJson::Type::PolymorphicModel))
-      end
-
       protected
       def convert_to_array(value)
         if value.kind_of?(Hash)

--- a/spec/nested_attributes/nested_attributes_spec.rb
+++ b/spec/nested_attributes/nested_attributes_spec.rb
@@ -382,12 +382,13 @@ RSpec.describe AttrJson::NestedAttributes do
 
         self.table_name = "products"
 
+        attr_json :primitive, :string
         attr_json :one_model, model_class_type, accepts_nested_attributes: false
         attr_json :many_models, model_class_type, array: true
       end
     end
 
-    it "applies default" do
+    it "applies default to model array attr" do
       expect(instance).to respond_to(:many_models_attributes=)
 
       instance.many_models_attributes = [{}]
@@ -397,7 +398,11 @@ RSpec.describe AttrJson::NestedAttributes do
       expect(instance.many_models.first.str).to eq("one")
     end
 
-    it "overrides false" do
+    it "does not apply default to non-applicable primitive" do
+      expect(instance).not_to respond_to(:primitive_attributes=)
+    end
+
+    it "can be overridden with false on specific attr" do
       expect(instance).not_to respond_to(:one_model_attributes=)
     end
   end

--- a/spec/nested_attributes/nested_attributes_spec.rb
+++ b/spec/nested_attributes/nested_attributes_spec.rb
@@ -36,6 +36,25 @@ RSpec.describe AttrJson::NestedAttributes do
     end
   end
 
+  describe "on primitive type" do
+    let(:klass) do
+      Class.new(ActiveRecord::Base) do
+        include AttrJson::Record
+        include AttrJson::NestedAttributes
+
+        self.table_name = "products"
+
+        attr_json :primitive, :string
+      end
+    end
+
+    it "raises as incompatible" do
+      expect {
+        klass.attr_json_accepts_nested_attributes_for :primitive
+      }.to raise_error(TypeError, "attr_json_accepts_nested_attributes_for is only for array or nested model types; `primitive` is type :string")
+    end
+  end
+
   it "should allow class to override and call super" do
     overridden_class = Class.new(klass) do
       def one_model_attributes=(attrs)


### PR DESCRIPTION
- config default_accepts_nested_attributes only applies to applicable model or array typed attributes
- remove Type::Array#base_type_primitive? for DRY and cleaner more readable intent
- refactor for more readable without nested condition, using new methods
- attr_json_accepts_nested_attributes_for raises TypeError if used with incompatible attribute type
