### PR TITLE
Fix AttrJson::Model#to_json regression

### DIFF
--- a/lib/attr_json/model.rb
+++ b/lib/attr_json/model.rb
@@ -352,7 +352,9 @@ module AttrJson
     #     * true => strip nils even if there is a default value -- in AttrJson
     #       context, this means the default will be reapplied over nil on
     #       every de-serialization!
-    def serializable_hash(strip_nils:false, **options)
+    def serializable_hash(options=nil)
+      strip_nils = options&.has_key?(:strip_nils) ? options.delete(:strip_nils) : false
+
       unless [true, false, :safely].include?(strip_nils)
         raise ArgumentError, ":strip_nils must be true, false, or :safely"
       end
@@ -384,8 +386,8 @@ module AttrJson
     #
     # @param strip_nils [:symbol, Boolean] (default false) [true, false, :safely],
     #   see #serializable_hash
-    def as_json(**kwargs)
-      serializable_hash(**kwargs)
+    def as_json(options=nil)
+      serializable_hash(options)
     end
 
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -3,6 +3,20 @@ require 'spec_helper'
 RSpec.describe AttrJson::Record do
   let(:instance) { klass.new }
 
+  describe "#to_json" do
+    let(:klass) do
+      Class.new do
+        include AttrJson::Model
+
+        attr_json :str_one, :string
+      end
+    end
+
+    it "works (regression)" do
+      expect(klass.new(str_one: "foo").to_json).to be_kind_of(String)
+    end
+  end
+
   describe "store_key" do
     let(:klass) do
       Class.new do


### PR DESCRIPTION
Method delegation around kw arg changes in ruby versions is really confusing; here we are over-riding methods called by Rails, makes it more confusing. Rails uses an explicit `(options=nil)` single positional for it's keyword args in these methods. We need to do the same to keep everything working.
