### PR TITLE
Restore AttrJson::Type::Array#base_type_primitive?, soft-deprecation only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ While it has some backwards incompat changes, this is expected not to be a chall
 
 * The `rails_attribute` param to `attr_json` or `attr_json_config` no longer exists. We now always create rails attributes for AttrJson::Record attributes. https://github.com/jrochkind/attr_json/pull/117 and https://github.com/jrochkind/attr_json/pull/158
 
-*  AttrJson::Type::Array#base_type_primitive? is gone. Doubt anyone used it externally. https://github.com/jrochkind/attr_json/pull/178
-
 ### Changed
 
 * We now create Rails Attribute cover for all attr_json attributes, and we do a better job of keeping the Rails attribute values sync'd with attr_json values.   https://github.com/jrochkind/attr_json/pull/117, https://github.com/jrochkind/attr_json/pull/158, and https://github.com/jrochkind/attr_json/pull/163

--- a/lib/attr_json/attribute_definition.rb
+++ b/lib/attr_json/attribute_definition.rb
@@ -96,14 +96,18 @@
 
     # Used for figuring out appropriate behavior for nested attribute implementation among
     # other places. true if type is a nested model, either straight or polymorphic
-    def single_model_type?(arg_type=self.type)
+    def single_model_type?
+      self.class.single_model_type?(type)
+    end
+
+    def self.single_model_type?(arg_type)
       arg_type.is_a?(AttrJson::Type::Model) || arg_type.is_a?(AttrJson::Type::PolymorphicModel)
     end
 
     # Used for figuring out appropriate behavior in nested attribute implementation among
     # other places. true if type is an array of things that are not nested models.
     def array_of_primitive_type?
-      array_type? && !single_model_type?(type.base_type)
+      array_type? && !self.class.single_model_type?(type.base_type)
     end
 
     # Can look up a symbol to a type, or leave a type alone, or raise if it's neither.

--- a/lib/attr_json/type/array.rb
+++ b/lib/attr_json/type/array.rb
@@ -45,6 +45,15 @@ module AttrJson
         ]
       end
 
+      # Soft-deprecated. You probably want to use
+      #
+      #    AttrJson::AttributeDefinition#array_of_primitive_type?
+      #
+      # instead where possible.
+      def base_type_primitive?
+        ! AttrJson::AttributeDefinition.single_model_type?(base_type)
+      end
+
       protected
       def convert_to_array(value)
         if value.kind_of?(Hash)


### PR DESCRIPTION
Turns out this was used in Kithe... it's just not worth it to break, it's fine to leave in, with just comment noting soft deprecation

Refactor to do it DIY, a bit cleaner anyway, that was too clever before.
