### PR TITLE
Actually fix running rails-edge rails 7.1 with rack 2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -37,11 +37,5 @@ appraise "rails-edge" do
   # Edge rails, future Rails 7.1 currently allows rack 3 -- but rails itself
   # and some of our other dependencies may not actually work with rack 3 yet,
   # let's test under rack 2. (Nothing in this gem deals with levels as low as rack)
-  #
-  # Bundler was having trouble resolving unless we specified rackup and rack-session
-  # limits too, I think it was a bundler failure, we actually only care about
-  # rack < 3 here.
   gem "rack", "~> 2.0"
-  gem "rackup", "< 2"
-  gem "rack-session", "< 2"
 end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -16,7 +16,5 @@ gem "webdrivers", "~> 5.0"
 gem "selenium-webdriver"
 gem "byebug"
 gem "rack", "~> 2.0"
-gem "rackup", "< 2"
-gem "rack-session", "< 2"
 
 gemspec path: "../"


### PR DESCRIPTION
The extra things we added to the rails-edge gemfile, even though we didn't think we should have to -- we didn't have to, and they were in fact getting in the way. Something got confused. Fixing.
