### PR TITLE
Refactor #attr_json_sync_to_rails_attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Refactor #attr_json_sync_to_rails_attributes for slightly improved performance. https://github.com/jrochkind/attr_json/pull/192
 
 *
 


### PR DESCRIPTION
To slightly improve performance (only fetch the container attribute once), but also to be ready for solving the bug from #190, with fetch and limited `select` columns.
