### PR TITLE
fix fetch with limited select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/jrochkind/attr_json/compare/v2.0.0...HEAD)
 
+
+### Fixed
+
+* You can now do a specified ActiveRecord `.select` without your json containers, to fetch an object with other attributes that you can access. https://github.com/jrochkind/attr_json/pull/193
+
 ### Changed
 
 * Refactor #attr_json_sync_to_rails_attributes for slightly improved performance. https://github.com/jrochkind/attr_json/pull/192

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -50,6 +50,9 @@ module AttrJson
     def attr_json_sync_to_rails_attributes
       self.class.attr_json_registry.definitions.group_by(&:container_attribute).each_pair do |container_attribute, definitions|
         begin
+          # column may have eg been left out of an explicit 'select'
+          next unless has_attribute?(container_attribute)
+
           container_value    = public_send(container_attribute)
 
           definitions.each do |attribute_def|

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -921,5 +921,27 @@ RSpec.describe AttrJson::Record do
 
   end
 
+  describe "with .select without json container" do
+    let(:record) do
+      klass.create(str: "str value", string_type: "direct in column")
+    end
 
+    let(:refetched_record) do
+      klass.select(:id, :string_type).find(record.id)
+    end
+
+    it "can fetch without raising" do
+      expect(refetched_record.string_type).to eq record.string_type
+    end
+
+    it "raises on read or write of attr_json attribute" do
+      expect {
+        refetched_record.str
+      }.to raise_error(ActiveModel::MissingAttributeError, /missing attribute: json_attribute/)
+
+      expect {
+        refetched_record.str = "new set value"
+      }.to raise_error(ActiveModel::MissingAttributeError, /missing attribute: json_attribute/)
+    end
+  end
 end


### PR DESCRIPTION
Actually reading or writing an attr_json attribute with a missing container attribute will still raise ActiveModel::MissingAttributeError, but you can now do a `select` without your json containers, to fetch an object with other attributes that you can access.

Ref #190