### PR TITLE
Safety guard in sync_to_rails_attributes against unknown edge case where container is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Refactor #attr_json_sync_to_rails_attributes for slightly improved performance. https://github.com/jrochkind/attr_json/pull/192
 
-*
+* Safety guard in sync_to_rails_attributes against unknown edge case where container is nil https://github.com/jrochkind/attr_json/pull/194
 
 *
 

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -55,6 +55,10 @@ module AttrJson
 
           container_value    = public_send(container_attribute)
 
+          # isn't expected to be possible to be nil rather than empty hash, but
+          # if it is from some edge case, well, we don't have values to sync, fine
+          next if container_value.nil?
+
           definitions.each do |attribute_def|
             attr_name     = attribute_def.name
             value         = container_value[attribute_def.store_key]


### PR DESCRIPTION
Can come up in use of ActiveRecord `becomes` as in #189, although currently other problems prevent `becomes` from working right anyway, as detailed there. 

But we can put this in to at least avoid that one problem, as well as any other unanticipated edge cases where the container can end up nil instead of empty hash. Best to code defensively here. 