### PR TITLE
Fix tests for changed error message formats in Rails 7.1 (off rails edge)

### DIFF
--- a/spec/integration/form_mega_spec.rb
+++ b/spec/integration/form_mega_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "form with simple_form and cocoon", type: :feature, js: true do
         expect(page).to have_current_path(documents_path)
         expect(page).to have_content "Person roles is invalid"
         within(".document_person_roles_people_given_name") do
-          expect(page).to have_content "can't be blank"
+          expect(page).to have_content(/can'|’t be blank/)
         end
       end
     end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe AttrJson::Record do
     it "has the usual validation errors" do
       instance.str = "nosize"
       expect(instance.valid?).to be false
-      expect(instance.errors[:str_array]).to eq(["can't be blank"])
+      expect(instance.errors[:str_array]).to eq(["can't be blank"]).or eq(["can’t be blank"])
       expect(instance.errors[:str]).to eq(["nosize is not a valid size"])
     end
     it "valid with valid data" do
@@ -259,7 +259,7 @@ RSpec.describe AttrJson::Record do
       expect(instance.errors[:nested]).to include("is invalid")
 
       expect(instance.nested.errors.key?(:str))
-      expect(instance.nested.errors[:str]).to include("can't be blank")
+      expect(instance.nested.errors[:str]).to include a_string_matching(/\Acan'|’t be blank\z/)
 
       expect(instance.errors.details[:nested].first[:value]).to be_kind_of(nested_class)
     end
@@ -295,7 +295,7 @@ RSpec.describe AttrJson::Record do
       expect(instance.errors[:nested]).to include("is invalid")
 
       expect(instance.nested.first.errors.key?(:str))
-      expect(instance.nested.first.errors[:str]).to include("can't be blank")
+      expect(instance.nested.first.errors[:str]).to include(/\Acan'|’t be blank\z/)
 
       expect(instance.errors.details[:nested].first[:value].first).to be_kind_of(nested_class)
     end

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -337,7 +337,7 @@ RSpec.describe AttrJson::Record do
     it "has the usual validation errors" do
       instance.str = "nosize"
       expect(instance.save).to be false
-      expect(instance.errors[:str_array]).to eq(["can't be blank"])
+      expect(instance.errors[:str_array]).to eq(["can't be blank"]).or eq(["can’t be blank"])
       expect(instance.errors[:str]).to eq(["nosize is not a valid size"])
     end
     it "saves with valid data" do

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -935,13 +935,14 @@ RSpec.describe AttrJson::Record do
     end
 
     it "raises on read or write of attr_json attribute" do
+      # Rails 7.1 changes format of message somewhat, we use regexp to match that and previous
       expect {
         refetched_record.str
-      }.to raise_error(ActiveModel::MissingAttributeError, /missing attribute: json_attribute/)
+      }.to raise_error(ActiveModel::MissingAttributeError, /missing attribute:? '?json_attributes'?/)
 
       expect {
         refetched_record.str = "new set value"
-      }.to raise_error(ActiveModel::MissingAttributeError, /missing attribute: json_attribute/)
+      }.to raise_error(ActiveModel::MissingAttributeError, /missing attribute:? '?json_attributes'?/)
     end
   end
 end

--- a/spec/record_with_model_spec.rb
+++ b/spec/record_with_model_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe AttrJson::Record do
       expect(instance.errors[:model]).to include("is invalid")
 
       expect(instance.model.errors.key?(:str))
-      expect(instance.model.errors[:str]).to include("can't be blank")
+      expect(instance.model.errors[:str]).to include(/\Acan'|’t be blank\z/)
 
       expect(instance.errors.details[:model].first[:value]).to be_kind_of(model_class)
     end


### PR DESCRIPTION
- Fix tests for new rails 7.1 use of curly quote in {can't be blank} error message
- fix test for slightly different error message format in Rails 7.1
