### PR TITLE
Move CI to Postgres 10, to avoid Rails 7.1.1 bug accidentally removing pg 9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
   tests:
     services:
       db:
-        image: postgres:9.4
+        # used to be 9.4, should work on 9.4, only moved to 10.0
+        # because of rails 7.1 bug (rails intends to support 9 too!)
+        # https://github.com/jrochkind/attr_json/issues/211
+        image: postgres:10.0
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -49,7 +52,7 @@ jobs:
 
           - gemfile: rails_7_0
             ruby: 3.2
-            
+
           - gemfile: rails_7_1
             ruby: '3.0'
 


### PR DESCRIPTION
A Rails 7.1.2 should restore it, we could test on pg 9 again then, although currently pg 11 is actually the minimum not EOL!

https://endoflife.date/postgresql

Closes #211
