### PR TITLE
Avoid private ActiveRecord API when lazily registering container attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *
 
+### Changed
+
+* Avoid private ActiveRecord API when lazily registering container attributes. (Compat with Rails post 7.1) https://github.com/jrochkind/attr_json/pull/214
+
 ## [2.2.0](https://github.com/jrochkind/attr_json/compare/v2.1.0...v2.2.0)
 
 ### Added


### PR DESCRIPTION
We were using a `attributes_to_define_after_schema_loads` method which was private API, and which breaks in current Rails main branch post 7.1 release.

We switch to only using standard attribute API, and keeping track ourselves internally if this is the "first time" a container attrib is encountered, so if it needs an attribute registration. We don't want to multiply register the same attribute many times becaues although it would work, it's just messy and extra objects and calls for rails.

This is working -- we had pretty good test coverage, which helped us realize we needed to track specific sub-class too, and tests now all pass.

In the long-run, we might like a different public API that doesn't require us to implicitly know when first time container attrib is encountered. Like requires you to explicitly group things by container attribute. Or... this works and is fine? Could be!

This is one part of #212 although other failures are revealed once we fix this one.
