### PR TITLE
Freeze more strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Avoid private ActiveRecord API when lazily registering container attributes. (Compat with Rails post 7.1) https://github.com/jrochkind/attr_json/pull/214
 
+* Freeze more strings to reduce String allocations https://github.com/jrochkind/attr_json/pull/216
+
 ## [2.2.0](https://github.com/jrochkind/attr_json/compare/v2.1.0...v2.2.0)
 
 ### Added

--- a/lib/attr_json.rb
+++ b/lib/attr_json.rb
@@ -10,5 +10,25 @@ require 'attr_json/record/query_scopes'
 require 'attr_json/type/polymorphic_model'
 
 module AttrJson
-
+  # We need to convert Symbols to strings a lot at present -- ActiveRecord does too, so
+  # not too suprrising.
+  #
+  # In Rails 3.0 and above, we can use Symbol#name to get a frozen string back
+  # and avoid extra allocations. https://bugs.ruby-lang.org/issues/16150
+  #
+  # Ruby 2.7 doens't yet have it though. As long as we are supporting ruby 2.7,
+  # we'll just check at runtime to keep this lean
+  if RUBY_VERSION.split('.').first.to_i >= 3
+    def self.efficient_to_s(obj)
+      if obj.kind_of?(Symbol)
+        obj.name
+      else
+        obj.to_s
+      end
+    end
+  else
+    def self.efficient_to_s(obj)
+      obj.to_s
+    end
+  end
 end

--- a/lib/attr_json/attribute_definition.rb
+++ b/lib/attr_json/attribute_definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
  require 'attr_json/type/array'
 
  module AttrJson

--- a/lib/attr_json/attribute_definition.rb
+++ b/lib/attr_json/attribute_definition.rb
@@ -64,7 +64,7 @@
     end
 
     def store_key
-      (@store_key || name).to_s
+      AttrJson.efficient_to_s(@store_key || name)
     end
 
     def has_default?

--- a/lib/attr_json/attribute_definition/registry.rb
+++ b/lib/attr_json/attribute_definition/registry.rb
@@ -50,8 +50,8 @@ module AttrJson
 
       # Can return nil if none found.
       def store_key_lookup(container_attribute, store_key)
-        @store_key_to_definition[container_attribute.to_s] &&
-          @store_key_to_definition[container_attribute.to_s][store_key.to_s]
+        @store_key_to_definition[AttrJson.efficient_to_s(container_attribute)] &&
+          @store_key_to_definition[AttrJson.efficient_to_s(container_attribute)][AttrJson.efficient_to_s(store_key)]
       end
 
       def definitions
@@ -64,7 +64,7 @@ module AttrJson
       end
 
       def container_attributes
-        @store_key_to_definition.keys.collect(&:to_s)
+        @store_key_to_definition.keys.collect { |s| AttrJson.efficient_to_s(s) }
       end
 
       # This is how you register additional definitions, as a non-mutating
@@ -114,14 +114,14 @@ module AttrJson
       end
 
       def store_key_index!(definition)
-        container_hash = (@store_key_to_definition[definition.container_attribute.to_s] ||= {})
+        container_hash = (@store_key_to_definition[AttrJson.efficient_to_s(definition.container_attribute)] ||= {})
 
-        if container_hash.has_key?(definition.store_key.to_s)
-          existing = container_hash[definition.store_key.to_s]
+        if container_hash.has_key?(AttrJson.efficient_to_s(definition.store_key))
+          existing = container_hash[AttrJson.efficient_to_s(definition.store_key)]
           raise ArgumentError, "Can't add, store key `#{definition.store_key}` conflicts with existing attribute: #{existing.original_args}"
         end
 
-        container_hash[definition.store_key.to_s] = definition
+        container_hash[AttrJson.efficient_to_s(definition.store_key)] = definition
       end
     end
   end

--- a/lib/attr_json/attribute_definition/registry.rb
+++ b/lib/attr_json/attribute_definition/registry.rb
@@ -27,7 +27,8 @@ module AttrJson
       def initialize(hash = {})
         @name_to_definition = hash.dup
         @store_key_to_definition = {}
-        definitions.each { |d| store_key_index!(d) }
+
+        @name_to_definition.values.each { |d| store_key_index!(d) }
 
         @container_attributes_registered = Hash.new { Set.new }
       end
@@ -55,7 +56,8 @@ module AttrJson
       end
 
       def definitions
-        @name_to_definition.values
+        # Since we are immutable, we can cache this to avoid allocation in a hot spot
+        @stored_definitions ||= @name_to_definition.values
       end
 
       # Returns all registered attributes as an array of symbols
@@ -111,6 +113,8 @@ module AttrJson
         end
         @name_to_definition[definition.name.to_sym] = definition
         store_key_index!(definition)
+
+        @stored_definitions = nil
       end
 
       def store_key_index!(definition)

--- a/lib/attr_json/attribute_definition/registry.rb
+++ b/lib/attr_json/attribute_definition/registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'attr_json/attribute_definition'
 
 module AttrJson

--- a/lib/attr_json/model.rb
+++ b/lib/attr_json/model.rb
@@ -138,8 +138,8 @@ module AttrJson
       def new_from_serializable(attributes = {})
         attributes = attributes.collect do |key, value|
           # store keys in arguments get translated to attribute names on initialize.
-          if attribute_def = self.attr_json_registry.store_key_lookup("", key.to_s)
-            key = attribute_def.name.to_s
+          if attribute_def = self.attr_json_registry.store_key_lookup("".freeze, AttrJson.efficient_to_s(key))
+            key = AttrJson.efficient_to_s(attribute_def.name)
           end
 
           attr_type = self.attr_json_registry.has_attribute?(key) && self.attr_json_registry.type_for_attribute(key)
@@ -186,7 +186,7 @@ module AttrJson
 
       # like the ActiveModel::Attributes method, hash with name keys, and ActiveModel::Type values
       def attribute_types
-        attribute_names.collect { |name| [name.to_s, attr_json_registry.type_for_attribute(name)]}.to_h
+        attribute_names.collect { |name| [AttrJson.efficient_to_s(name), attr_json_registry.type_for_attribute(name)]}.to_h
       end
 
 
@@ -227,11 +227,11 @@ module AttrJson
 
         _attr_jsons_module.module_eval do
           define_method("#{name}=") do |value|
-            _attr_json_write(name.to_s, value)
+            _attr_json_write(AttrJson.efficient_to_s(name), value)
           end
 
           define_method("#{name}") do
-            attributes[name.to_s]
+            attributes[AttrJson.efficient_to_s(name)]
           end
         end
       end
@@ -429,7 +429,7 @@ module AttrJson
 
     def fill_in_defaults!
       self.class.attr_json_registry.definitions.each do |definition|
-        if definition.has_default? && !attributes.has_key?(definition.name.to_s)
+        if definition.has_default? && !attributes.has_key?(AttrJson.efficient_to_s(definition.name))
           self.send("#{definition.name.to_s}=", definition.provide_default!)
         end
       end
@@ -437,10 +437,10 @@ module AttrJson
 
     def _attr_json_write(key, value)
       if attribute_def = self.class.attr_json_registry[key.to_sym]
-        attributes[key.to_s] = attribute_def.cast(value)
+        attributes[AttrJson.efficient_to_s(key)] = attribute_def.cast(value)
       else
         # TODO, strict mode, ignore, raise, allow.
-        attributes[key.to_s] = value
+        attributes[AttrJson.efficient_to_s(key)] = value
       end
     end
 

--- a/lib/attr_json/model.rb
+++ b/lib/attr_json/model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/concern'
 require 'active_model/type'
 

--- a/lib/attr_json/nested_attributes.rb
+++ b/lib/attr_json/nested_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'attr_json/nested_attributes/builder'
 require 'attr_json/nested_attributes/writer'
 

--- a/lib/attr_json/nested_attributes/builder.rb
+++ b/lib/attr_json/nested_attributes/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AttrJson
   module NestedAttributes
     # Implementation of `build_` methods, called by the `build_` methods

--- a/lib/attr_json/nested_attributes/multiparameter_attribute_writer.rb
+++ b/lib/attr_json/nested_attributes/multiparameter_attribute_writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AttrJson
   module NestedAttributes
     # Rails has a weird "multiparameter attribute" thing, that is used for simple_form's

--- a/lib/attr_json/nested_attributes/writer.rb
+++ b/lib/attr_json/nested_attributes/writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'attr_json/nested_attributes/multiparameter_attribute_writer'
 
 module AttrJson

--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'attr_json/attribute_definition'
 require 'attr_json/attribute_definition/registry'
 require 'attr_json/type/container_attribute'

--- a/lib/attr_json/record/query_builder.rb
+++ b/lib/attr_json/record/query_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AttrJson
   module Record
     # Implementation class called by #jsonb_contains scope method. Ordinarily

--- a/lib/attr_json/record/query_scopes.rb
+++ b/lib/attr_json/record/query_scopes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'attr_json/record/query_builder'
 
 module AttrJson

--- a/lib/attr_json/serialization_coder_from_type.rb
+++ b/lib/attr_json/serialization_coder_from_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AttrJson
 
   # A little wrapper to provide an object that provides #dump and #load method for use

--- a/lib/attr_json/type/array.rb
+++ b/lib/attr_json/type/array.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AttrJson
   module Type
     # You can wrap any ActiveModel::Type in one of these, and it's magically

--- a/lib/attr_json/type/container_attribute.rb
+++ b/lib/attr_json/type/container_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AttrJson
   module Type
     # A type that gets applied to the AR container/store jsonb attribute,

--- a/lib/attr_json/type/model.rb
+++ b/lib/attr_json/type/model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AttrJson
   module Type
     # An ActiveModel::Type representing a particular AttrJson::Model

--- a/lib/attr_json/type/polymorphic_model.rb
+++ b/lib/attr_json/type/polymorphic_model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AttrJson
   module Type
     # AttrJson::Type::PolymorphicModel can be used to create attr_json attributes


### PR DESCRIPTION
frozen string comment pragma at top of files: This does actually make a significant difference in string allocations in some places, we have a lot of string literals in hot spots

Not totally sure how much this matters in practice for performance, but doesn't hurt. 
