### PR TITLE
Keep nested model validation working in Rails post 7.1 (undefined method `custom_validation_context?')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Keep nested model validation working in Rails post-7.1, by no longer trying to re-use ActiveRecord::Validations::AssociatedValidator, instead supplying our own custom code. https://github.com/jrochkind/attr_json/pull/220
 
 *
 

--- a/lib/attr_json/model/nested_model_validator.rb
+++ b/lib/attr_json/model/nested_model_validator.rb
@@ -1,0 +1,27 @@
+module AttrJson
+  module Model
+    # Used to validate an attribute in an AttrJson::Model whose values are other models, when
+    # you want validation errors on the nested models to post up.
+    #
+    # This is based on ActiveRecord's own ActiveRecord::Validations::AssociatedValidator, and actually forked
+    # from it at https://github.com/rails/rails/blob/e37adfed4eff3b43350ec87222a922e9c72d9c1b/activerecord/lib/active_record/validations/associated.rb
+    #
+    # We used to simply use an ActiveRecord::Validations::AssociatedValidator, but as of https://github.com/jrochkind/attr_json/pull/220 (e1e798142d)
+    # it got ActiveRecord-specific functionality that no longer worked with our use case.
+    #
+    # No problem, the implementation is simple, we can provide it here, based on the last version that did work.
+    class NestedModelValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        if Array(value).reject { |r| valid_object?(r) }.any?
+          record.errors.add(attribute, :invalid, **options.merge(value: value))
+        end
+      end
+
+      private
+        def valid_object?(record)
+          #(record.respond_to?(:marked_for_destruction?) && record.marked_for_destruction?) || record.valid?
+          record.valid?
+        end
+    end
+  end
+end


### PR DESCRIPTION
Without using ActiveRecord::Validations::AssociatedValidator -- we now supply our own custom validation code, based on the same basic thing it was doing.

We had been using this ActiveRecord class in an analogous context for our AttrJson-specific nested model validations. And it used to work, because the code was simple enough. But as a result of https://github.com/rails/rails/pull/46238 , it started to contain some ActiveRecord-specific logic that broke us in our analagous use case.

No problem, we can just supply validation code ourselves, forked from the last working copy. It's very simple logic.

We even had a note to ourselves in a comment that we might have to do this at some point!

In Rails post-7.1, after Rails e1e798142, _without_ this PR you'd get error:

> undefined method `custom_validation_context?' for an instance of...
