### PR TITLE
Allow double parens in SQL spec

### DIFF
--- a/spec/query_scopes_spec.rb
+++ b/spec/query_scopes_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe AttrJson::Record::QueryScopes do
   describe "#not_jsonb_contains" do
     it 'generates a negated query' do
       query = klass.not_jsonb_contains(str: 'foo')
-
-      expect(query.to_sql).to match(/WHERE \(?NOT \(products.json_attributes @> \('{"str":"foo"}'\)::jsonb\)/)
+      # Rails 8 has double parens for some reason, previous does not
+      expect(query.to_sql).to match(/WHERE \(?NOT \(?\(products.json_attributes @> \('{"str":"foo"}'\)::jsonb\)\)?/)
     end
   end
 

--- a/spec/type/polymorphic_type_spec.rb
+++ b/spec/type/polymorphic_type_spec.rb
@@ -262,15 +262,18 @@ RSpec.describe AttrJson::Type::PolymorphicModel do
   describe "not_jsonb_contains" do
     it "can create keypath query" do
       sql = klass.not_jsonb_contains("one_poly.bool" => true).to_sql
-      expect(sql).to match(/WHERE \(?NOT \(products.json_attributes @> \('{\"one_poly\":{\"bool\":true}}'\)/)
+      # Rails 8 has double parens for some reason, previous does not
+      expect(sql).to match(/WHERE \(?NOT \(?\(products.json_attributes @> \('{\"one_poly\":{\"bool\":true}}'\)\)?/)
     end
     it "can create keypath query with type" do
       sql = klass.not_jsonb_contains("one_poly" => {"bool" => true, "type" => "Model2"}).to_sql
-      expect(sql).to match(/WHERE \(?NOT \(products.json_attributes @> \('{\"one_poly\":{\"bool\":true,\"type\":\"Model2\"}}'\)/)
+      # Rails 8 has double parens for some reason, previous does not
+      expect(sql).to match(/WHERE \(?NOT \(?\(products.json_attributes @> \('{\"one_poly\":{\"bool\":true,\"type\":\"Model2\"}}'\)\)?/)
     end
     it "can create keypath query with model arg" do
       sql = klass.not_jsonb_contains("one_poly" => model2.new(bool: true)).to_sql
-      expect(sql).to match(/WHERE \(?NOT \(products.json_attributes @> \('{\"one_poly\":{\"bool\":true,\"type\":\"Model2\"}}'\)/)
+      # Rails 8 has double parens for some reason, previous does not
+      expect(sql).to match(/WHERE \(?NOT \(?\(products.json_attributes @> \('{\"one_poly\":{\"bool\":true,\"type\":\"Model2\"}}'\)\)?/)
     end
   end
 end


### PR DESCRIPTION
On Rails post-7.1 edge @ c402ec78724a, SQL generated for certain 'NOT' queries has a double set of parens nested.

Our spec testing for SQL then fails.  We modify it to accept double set of parens.  This makes no semantic difference, our code was working on this version of Rails regardless; the spec just has to accep the variant SQL that means the same thing.

(No idea why Rails changed to generate a double set of parens here, or if it's a bug somewhere; but the SQL still works fine, an unnecessary double set of parens doesn't hurt anything I'm aware of, so I'm not going to worry about it).
