### PR TITLE
Workaround bug where rails does not 'require' logger

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,14 @@ require 'bundler'
 # replace manual requires with? :
 # #Bundler.require :default, :development, :test
 
+# bug in Rails pre-7.0 requires us to manually 'require' logger dep, Rails isn't going
+# to release a fix. https://github.com/rails/rails/pull/54264
+#
+# Tried to do this conditionally only if Rails < 7.1, but hard with order of
+# dependency loading. This is fine.
+require 'logger'
+
+
 require 'uri'
 require 'combustion'
 Combustion.initialize! :all do


### PR DESCRIPTION
Logger got moved to default gems a while ago in ruby versions, and rails should have been 'require'ing it but wasn't. This was hidden by the fact that concurrent-ruby used to 'require' it, but no longer does. With recent versions of concurrent-ruby, somebody needs to 'require' logger -- Rails does not plan to release a fix for pre-7.1 rails.

So we can simply require it in our spec_helper for CI no big deal.

See https://github.com/rails/rails/pull/54264, and specifically on no fix releases planned for Rails less than 7.1, https://github.com/rails/rails/pull/54264#issuecomment-2596106532
