### PR TITLE
Fix dirty tracking for boolean attributes

### DIFF
--- a/lib/attr_json/record.rb
+++ b/lib/attr_json/record.rb
@@ -65,7 +65,7 @@ module AttrJson
             attr_name     = attribute_def.name
             value         = container_value[attribute_def.store_key]
 
-            if value
+            unless value.nil?
               # TODO, can we just make this use the setter?
               write_attribute(attr_name, value)
 

--- a/spec/record/rails_attribute_dirty_spec.rb
+++ b/spec/record/rails_attribute_dirty_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "ActiveRecord dirty tracking" do
       self.table_name = "products"
       attr_json :str, :string
       attr_json :int, :integer
+      attr_json :bool, :boolean
       # just to make our changes more sane, set no default
       attr_json :str_array, :string, array: true, default: AttrJson::AttributeDefinition::NO_DEFAULT_PROVIDED
       attr_json :embedded, model_class_type
@@ -178,6 +179,20 @@ RSpec.describe "ActiveRecord dirty tracking" do
         obj.str = "value"
         expect(obj.will_save_change_to_int?).to be false
         expect(obj.will_save_change_to_str?).to be true
+      end
+    end
+
+    describe "boolean attribute dirty tracking" do
+      it "does not report a change when assigning false to false" do
+        instance.bool = false
+        instance.save!
+        instance.reload
+        expect(instance.bool).to be false
+        expect(instance.changes.empty?).to be true
+
+        instance.assign_attributes({ str: "new", bool: false })
+        expect(instance.bool_changed?).to be false
+        expect(instance.str_changed?).to be true
       end
     end
   end


### PR DESCRIPTION
Hey there 👋
Thanks for this awesome gem! Love it!

I found a small bug with dirty tracking when working with boolean attributes.
Basically, when a boolean attribute is set to `false`, dirty tracking doesn’t work as expected.

I think it's easier to explain with an example:

Let's say we have an ActiveRecord model like this:
```ruby
class Article < ActiveRecord::Base
  include AttrJson::Record

  attr_json :str, :string
  attr_json :bool, :boolean
end
```

Create a new article, reload it, change the `str` attribute and check if the `bool` attribute has changed:
```bash
Article.create str: "foo", bool: true
article = Article.last
article.assign_attributes(str: "new str", bool: true)
article.bool_changed?
=> false
```

Works 🎉

Now the same, but with a `false` value:
```bash
Article.create str: "foo", bool: false
article = Article.last
article.assign_attributes(str: "new str", bool: false)
article.bool_changed?
=> true
```

Expected behavior: `article.bool_changed?` should return `false` because the value didn't change.
Actual behavior: it returns `true`.


---

The reason is that the [`write_attribute method`](https://github.com/jrochkind/attr_json/blob/115c3995bb7baf3b26f2965d2c137bf63c3b7585/lib/attr_json/record.rb#L70C15-L70C30) in `AttrJson::Record` doesn't get called, since the [condition `if value`](https://github.com/jrochkind/attr_json/blob/115c3995bb7baf3b26f2965d2c137bf63c3b7585/lib/attr_json/record.rb#L68) fails. When the boolean is set to `false`, the condition literally becomes `if false`, so the attribute isn’t written at all and remains nil. As a result, any assignment to the boolean attribute appears to be a change, even if the value is the same.

Hope that makes sense.
Let me know if you'd like any changes to the fix or the test. Happy to tweak as needed.