### PR TITLE
Don't try to load rails_ujs, doesn't look like we were using it

### DIFF
--- a/.github/workflows/future_rails_ci.yml
+++ b/.github/workflows/future_rails_ci.yml
@@ -22,6 +22,8 @@ on:
   # UTC Sundays 0900. note, no notifications will be sent for failed scheduled builds. :(
   schedule:
     - cron: '0 9 * * SUN'
+  pull_request:
+    branches: [ '**' ]
 
 env:
   POSTGRES_USER: postgres

--- a/spec/internal/app/assets/javascripts/application.js
+++ b/spec/internal/app/assets/javascripts/application.js
@@ -11,5 +11,4 @@
 // about supported directives.
 //
 //= require jquery3
-//= require rails-ujs
 //= require cocoon


### PR DESCRIPTION
We stopped passing CI against edge Rails 8.2.0.alpha, in this run: https://github.com/jrochkind/attr_json/actions/runs/24303688018

Looks like Rails 8.2 will not include rails-ujs, and our test application.js trying to load it caused failure. 

Looks like test pass without it -- cocoon does not depend on it -- wasn't sure if we needed it for like rails CSRF, but tests seem to be passing anyway, so good enough?